### PR TITLE
Unity: Fix duplicate hosts created with same name(ported to newton)

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -127,11 +127,7 @@ class MockClient(object):
             raise ex.SnapDeleteIsCalled()
 
     @staticmethod
-    def create_host(name, uids):
-        return test_client.MockResource(name=name)
-
-    @staticmethod
-    def get_host(name):
+    def create_host(name):
         return test_client.MockResource(name=name)
 
     @staticmethod
@@ -187,6 +183,10 @@ class MockClient(object):
             return test_client.MockResource(_id=name)
         else:
             raise ex.UnityThinCloneLimitExceededError
+
+    @staticmethod
+    def update_host_initiators(host, wwns):
+        return None
 
     @property
     def system(self):

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -12,16 +12,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
 import unittest
 
 from mock import mock
 from oslo_utils import units
 
+from cinder import coordination
 from cinder.tests.unit.volume.drivers.dell_emc.unity \
     import fake_exception as ex
 from cinder.volume.drivers.dell_emc.unity import client
-
 
 ########################
 #
@@ -48,6 +47,7 @@ class MockResource(object):
         self.max_kbps = None
         self.pool_name = 'Pool0'
         self._storage_resource = None
+        self.host_cache = []
 
     @property
     def id(self):
@@ -250,6 +250,10 @@ class MockSystem(object):
     def get_host(name):
         if name == 'not_found':
             raise ex.UnityResourceNotFoundError()
+        if name == 'host1':
+            ret = MockResource(name)
+            ret.initiator_id = ['old-iqn']
+            return ret
         return MockResource(name)
 
     @staticmethod
@@ -410,16 +414,18 @@ class ClientTest(unittest.TestCase):
         ret = self.client.get_snap('not_found')
         self.assertIsNone(ret)
 
-    def test_create_host_found(self):
-        iqns = ['iqn.1-1.com.e:c.a.a0']
-        host = self.client.create_host('host1', iqns)
+    @mock.patch.object(coordination.Coordinator, 'get_lock')
+    def test_create_host_found(self, fake_coordination):
+        host = self.client.create_host('host1')
 
         self.assertEqual('host1', host.name)
         self.assertLessEqual(['iqn.1-1.com.e:c.a.a0'], host.initiator_id)
 
-    def test_create_host_not_found(self):
-        host = self.client.create_host('not_found', [])
+    @mock.patch.object(coordination.Coordinator, 'get_lock')
+    def test_create_host_not_found(self, fake):
+        host = self.client.create_host('not_found')
         self.assertEqual('not_found', host.name)
+        self.assertIn('not_found', self.client.host_cache)
 
     def test_attach_lun(self):
         lun = MockResource(_id='lun1', name='l1')
@@ -440,8 +446,20 @@ class ClientTest(unittest.TestCase):
 
         self.assertRaises(ex.DetachIsCalled, f)
 
-    def test_get_host(self):
-        self.assertEqual('host2', self.client.get_host('host2').name)
+    @mock.patch.object(coordination.Coordinator, 'get_lock')
+    def test_create_host(self, fake):
+        self.assertEqual('host2', self.client.create_host('host2').name)
+
+    @mock.patch.object(coordination.Coordinator, 'get_lock')
+    def test_create_host_in_cache(self, fake):
+        self.client.host_cache['already_in'] = MockResource(name='already_in')
+        host = self.client.create_host('already_in')
+        self.assertIn('already_in', self.client.host_cache)
+        self.assertEqual('already_in', host.name)
+
+    def test_update_host_initiators(self):
+        host = MockResource(name='host_init')
+        host = self.client.update_host_initiators(host, 'fake-iqn-1')
 
     def test_get_iscsi_target_info(self):
         ret = self.client.get_iscsi_target_info()

--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -24,10 +24,10 @@ else:
     # Set storops_ex to be None for unit test
     storops_ex = None
 
+from cinder import coordination
 from cinder import exception
 from cinder.i18n import _, _LW
 from cinder.volume.drivers.dell_emc.unity import utils
-
 
 LOG = log.getLogger(__name__)
 
@@ -43,6 +43,7 @@ class UnityClient(object):
         self.username = username
         self.password = password
         self.verify_cert = verify_cert
+        self.host_cache = {}
 
     @property
     def system(self):
@@ -186,28 +187,40 @@ class UnityClient(object):
                 {'name': name, 'err': err})
         return None
 
-    def create_host(self, name, uids):
-        """Creates a host on Unity.
+    @coordination.synchronized('{self.host}-{name}')
+    def create_host(self, name):
+        """Provides existing host if exists else create one."""
+        if name not in self.host_cache:
+            try:
+                host = self.system.get_host(name=name)
+            except storops_ex.UnityResourceNotFoundError:
+                LOG.debug('Host %s not found.  Create a new one.',
+                          name)
+                host = self.system.create_host(name=name)
 
-        Creates a host on Unity which has the uids associated.
+            self.host_cache[name] = host
+        else:
+            host = self.host_cache[name]
+        return host
 
-        :param name: name of the host
-        :param uids: iqns or wwns list
-        :return: UnitHost object
-        """
-
-        try:
-            host = self.system.get_host(name=name)
-        except storops_ex.UnityResourceNotFoundError:
-            LOG.debug('Existing host %s not found.  Create a new one.', name)
-            host = self.system.create_host(name=name)
-
+    def update_host_initiators(self, host, uids):
+        """Updates host with the supplied uids."""
         host_initiators_ids = self.get_host_initiator_ids(host)
         un_registered = [h for h in uids if h not in host_initiators_ids]
-        for uid in un_registered:
-            host.add_initiator(uid, force_create=True)
+        if un_registered:
+            for uid in un_registered:
+                try:
+                    host.add_initiator(uid, force_create=True)
+                except storops_ex.UnityHostInitiatorExistedError:
+                    # This make concurrent modification of
+                    # host initiators safe
+                    LOG.debug(
+                        'The uid(%s) was already in '
+                        '%s.', uid, host.name)
+            host.update()
+            # Update host cached with new initiators.
+            self.host_cache[host.name] = host
 
-        host.update()
         return host
 
     @staticmethod
@@ -240,9 +253,6 @@ class UnityClient(object):
         """
         lun_or_snap.update()
         host.detach(lun_or_snap)
-
-    def get_host(self, name):
-        return self.system.get_host(name=name)
 
     def get_ethernet_ports(self):
         return self.system.get_ethernet_port()


### PR DESCRIPTION
In some circumstance, there is a race condition in querying/creating
Unity host thus multiple hosts with same name were created.

This issue stops any further attach/detach operation.

This patch leverage the DSL in cinder to avoid above race condition.