### PR TITLE
Unity: add multiattach support

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -453,7 +453,8 @@ class CommonAdapterTest(unittest.TestCase):
 
     def test_terminate_connection_volume(self):
         def f():
-            volume = MockOSResource(provider_location='id^lun_43', id='id_43')
+            volume = MockOSResource(provider_location='id^lun_43', id='id_43',
+                                    volume_attachment=None)
             connector = {'host': 'host1'}
             self.adapter.terminate_connection(volume, connector)
 
@@ -461,7 +462,8 @@ class CommonAdapterTest(unittest.TestCase):
 
     def test_terminate_connection_force_detach(self):
         def f():
-            volume = MockOSResource(provider_location='id^lun_44', id='id_44')
+            volume = MockOSResource(provider_location='id^lun_44', id='id_44',
+                                    volume_attachment=None)
             self.adapter.terminate_connection(volume, None)
 
         self.assertRaises(ex.DetachAllIsCalled, f)
@@ -469,7 +471,8 @@ class CommonAdapterTest(unittest.TestCase):
     def test_terminate_connection_snapshot(self):
         def f():
             connector = {'host': 'host1'}
-            snap = MockOSResource(name='snap_0', id='snap_0')
+            snap = MockOSResource(name='snap_0', id='snap_0',
+                                  volume_attachment=None)
             self.adapter.terminate_connection_snapshot(snap, connector)
 
         self.assertRaises(ex.DetachIsCalled, f)
@@ -479,10 +482,26 @@ class CommonAdapterTest(unittest.TestCase):
 
         def f():
             connector = {'host': 'empty-host'}
-            vol = MockOSResource(provider_location='id^lun_45', id='id_45')
+            vol = MockOSResource(provider_location='id^lun_45', id='id_45',
+                                 volume_attachment=None)
             self.adapter.terminate_connection(vol, connector)
 
         self.assertRaises(ex.HostDeleteIsCalled, f)
+
+    def test_terminate_connection_multiattached_volume(self):
+        def f():
+            connector = {'host': 'host1'}
+            attachments = [MockOSResource(id='id-1',
+                                          attach_status='attached',
+                                          attached_host='host1'),
+                           MockOSResource(id='id-2',
+                                          attach_status='attached',
+                                          attached_host='host1')]
+            vol = MockOSResource(provider_location='id^lun_45', id='id_45',
+                                 volume_attachment=attachments)
+            self.adapter.terminate_connection(vol, connector)
+
+        self.assertIsNone(f())
 
     def test_manage_existing_by_name(self):
         ref = {'source-id': 12}
@@ -795,7 +814,8 @@ class FCAdapterTest(unittest.TestCase):
 
     def test_terminate_connection_auto_zone_enabled(self):
         connector = {'host': 'host1', 'wwpns': 'abcdefg'}
-        volume = MockOSResource(provider_location='id^lun_41', id='id_41')
+        volume = MockOSResource(provider_location='id^lun_41', id='id_41',
+                                volume_attachment=None)
         ret = self.adapter.terminate_connection(volume, connector)
         self.assertEqual('fibre_channel', ret['driver_volume_type'])
         data = ret['data']
@@ -808,7 +828,8 @@ class FCAdapterTest(unittest.TestCase):
 
     def test_terminate_connection_auto_zone_enabled_none_host_luns(self):
         connector = {'host': 'host-no-host_luns', 'wwpns': 'abcdefg'}
-        volume = MockOSResource(provider_location='id^lun_41', id='id_41')
+        volume = MockOSResource(provider_location='id^lun_41', id='id_41',
+                                volume_attachment=None)
         ret = self.adapter.terminate_connection(volume, connector)
         self.assertEqual('fibre_channel', ret['driver_volume_type'])
         data = ret['data']
@@ -822,7 +843,8 @@ class FCAdapterTest(unittest.TestCase):
     def test_terminate_connection_remove_empty_host_return_data(self):
         self.adapter.remove_empty_host = True
         connector = {'host': 'empty-host-return-data', 'wwpns': 'abcdefg'}
-        volume = MockOSResource(provider_location='id^lun_41', id='id_41')
+        volume = MockOSResource(provider_location='id^lun_41', id='id_41',
+                                volume_attachment=None)
         ret = self.adapter.terminate_connection(volume, connector)
         self.assertEqual('fibre_channel', ret['driver_volume_type'])
         data = ret['data']

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -63,7 +63,7 @@ class MockResource(object):
             raise ex.UnityResourceNotFoundError()
         elif self.get_id() == 'snap_in_use':
             raise ex.UnityDeleteAttachedSnapError()
-        elif self.name == 'empty_host':
+        elif self.name == 'empty-host':
             raise ex.HostDeleteIsCalled()
 
     @property
@@ -541,7 +541,8 @@ class ClientTest(unittest.TestCase):
     def test_delete_host_wo_lock(self):
         host = MockResource(name='empty-host')
         self.assertRaises(ex.HostDeleteIsCalled,
-                          self.client.delete_host_wo_lock(host))
+                          self.client.delete_host_wo_lock,
+                          host)
 
     def test_delete_host_wo_lock_remove_from_cache(self):
         host = MockResource(name='empty-host-in-cache')

--- a/cinder/volume/drivers/dell_emc/unity/adapter.py
+++ b/cinder/volume/drivers/dell_emc/unity/adapter.py
@@ -331,12 +331,14 @@ class CommonAdapter(object):
         # No target info for iSCSI driver
         return []
 
-    def _detach_and_delete_host(self, host_name, lun_or_snap):
+    def _detach_and_delete_host(self, host_name, lun_or_snap,
+                                is_multiattach_to_host=False):
         @utils.lock_if(self.to_lock_host, '{lock_name}')
         def _lock_helper(lock_name):
             # Only get the host from cache here
             host = self.client.create_host_wo_lock(host_name)
-            self.client.detach(host, lun_or_snap)
+            if not is_multiattach_to_host:
+                self.client.detach(host, lun_or_snap)
             host.update()  # need update to get the latest `host_luns`
             targets = self.filter_targets_by_host(host)
             if self.remove_empty_host and not host.host_luns:
@@ -352,14 +354,16 @@ class CommonAdapter(object):
         return {}
 
     @cinder_utils.trace
-    def _terminate_connection(self, lun_or_snap, connector):
+    def _terminate_connection(self, lun_or_snap, connector,
+                              is_multiattach_to_host=False):
         is_force_detach = connector is None
         data = {}
         if is_force_detach:
             self.client.detach_all(lun_or_snap)
         else:
-            targets = self._detach_and_delete_host(connector['host'],
-                                                   lun_or_snap)
+            targets = self._detach_and_delete_host(
+                connector['host'], lun_or_snap,
+                is_multiattach_to_host=is_multiattach_to_host)
             data = self.get_terminate_connection_info(connector, targets)
         return {
             'driver_volume_type': self.driver_volume_type,
@@ -369,7 +373,14 @@ class CommonAdapter(object):
     @cinder_utils.trace
     def terminate_connection(self, volume, connector):
         lun = self.client.get_lun(lun_id=self.get_lun_id(volume))
-        return self._terminate_connection(lun, connector)
+        # None `connector` indicates force detach, then detach all even the
+        # volume is multi-attached.
+        multiattach_flag = (connector is not None and
+                            utils.is_multiattach_to_host(
+                                volume.volume_attachment,
+                                connector['host']))
+        return self._terminate_connection(
+            lun, connector, is_multiattach_to_host=multiattach_flag)
 
     def get_connector_uids(self, connector):
         return None
@@ -427,7 +438,9 @@ class CommonAdapter(object):
             'thin_provisioning_support': True,
             'thick_provisioning_support': False,
             'max_over_subscription_ratio': (
-                self.max_over_subscription_ratio)}
+                self.max_over_subscription_ratio),
+            'multiattach': True
+        }
 
     def get_lun_id(self, volume):
         """Retrieves id of the volume's backing LUN.

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -53,11 +53,15 @@ class UnityDriver(driver.ManageableVD,
     """Unity Driver.
 
     Version history:
+
+    .. code-block:: none
+
         1.0.0 - Initial version
         2.0.0 - Add thin clone support
+        2.1.0 - Cherry-pick the multi-attach support
     """
 
-    VERSION = '02.00.00'
+    VERSION = '02.01.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/cinder/volume/drivers/dell_emc/unity/utils.py
+++ b/cinder/volume/drivers/dell_emc/unity/utils.py
@@ -26,6 +26,7 @@ import six
 from cinder import coordination
 from cinder import exception
 from cinder.i18n import _
+from cinder.objects import fields
 from cinder.volume import utils as vol_utils
 from cinder.volume import volume_types
 from cinder.zonemanager import utils as zm_utils
@@ -300,3 +301,18 @@ def lock_if(condition, lock_name):
         return coordination.synchronized(lock_name)
     else:
         return functools.partial
+
+
+def is_multiattach_to_host(volume_attachment, host_name):
+    # When multiattach is enabled, a volume could be attached to two or more
+    # instances which are hosted on one nova host.
+    # Because unity cannot recognize the volume is attached to two or more
+    # instances, we should keep the volume attached to the nova host until
+    # the volume is detached from the last instance.
+    if not volume_attachment:
+        return False
+
+    attachment = [a for a in volume_attachment
+                  if a.attach_status == fields.VolumeAttachStatus.ATTACHED and
+                  a.attached_host == host_name]
+    return len(attachment) > 1

--- a/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
@@ -1,0 +1,410 @@
+=====================
+Dell EMC Unity driver
+=====================
+
+Unity driver has been integrated in the OpenStack Block Storage project since
+the Ocata release. The driver is built on the top of Block Storage framework
+and a Dell EMC distributed Python package
+`storops <https://pypi.python.org/pypi/storops>`_.
+
+Prerequisites
+~~~~~~~~~~~~~
+
++-------------------+-----------------+
+|    Software       |    Version      |
++===================+=================+
+| Unity OE          | 4.1.X or newer  |
++-------------------+-----------------+
+| storops           | 0.5.10 or newer |
++-------------------+-----------------+
+
+
+Supported operations
+~~~~~~~~~~~~~~~~~~~~
+
+- Create, delete, attach, and detach volumes.
+- Create, list, and delete volume snapshots.
+- Create a volume from a snapshot.
+- Copy an image to a volume.
+- Create an image from a volume.
+- Clone a volume.
+- Extend a volume.
+- Migrate a volume.
+- Get volume statistics.
+- Efficient non-disruptive volume backup.
+- Revert a volume to a snapshot.
+- Create thick volumes.
+- Attach a volume to multiple servers simultaneously (multiattach).
+
+Driver configuration
+~~~~~~~~~~~~~~~~~~~~
+
+.. note:: The following instructions should all be performed on Black Storage
+          nodes.
+
+#. Install `storops` from pypi:
+
+   .. code-block:: console
+
+      # pip install storops
+
+
+#. Add the following content into ``/etc/cinder/cinder.conf``:
+
+   .. code-block:: ini
+
+      [DEFAULT]
+      enabled_backends = unity
+
+      [unity]
+      # Storage protocol
+      storage_protocol = iSCSI
+      # Unisphere IP
+      san_ip = <SAN IP>
+      # Unisphere username and password
+      san_login = <SAN LOGIN>
+      san_password = <SAN PASSWORD>
+      # Volume driver name
+      volume_driver = cinder.volume.drivers.dell_emc.unity.Driver
+      # backend's name
+      volume_backend_name = Storage_ISCSI_01
+
+   .. note:: These are minimal options for Unity driver, for more options,
+             see `Driver options`_.
+
+
+.. note:: (**Optional**) If you require multipath based data access, perform
+          below steps on both Block Storage and Compute nodes.
+
+
+#. Install ``sysfsutils``, ``sg3-utils`` and ``multipath-tools``:
+
+   .. code-block:: console
+
+      # apt-get install multipath-tools sg3-utils sysfsutils
+
+
+#. (Required for FC driver in case `Auto-zoning Support`_ is disabled) Zone the
+   FC ports of Compute nodes with Unity FC target ports.
+
+
+#. Enable Unity storage optimized multipath configuration:
+
+   Add the following content into ``/etc/multipath.conf``
+
+   .. code-block:: vim
+
+      blacklist {
+          # Skip the files uner /dev that are definitely not FC/iSCSI devices
+          # Different system may need different customization
+          devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+          devnode "^hd[a-z][0-9]*"
+          devnode "^cciss!c[0-9]d[0-9]*[p[0-9]*]"
+
+          # Skip LUNZ device from VNX/Unity
+          device {
+              vendor "DGC"
+              product "LUNZ"
+          }
+      }
+
+      defaults {
+          user_friendly_names no
+          flush_on_last_del yes
+      }
+
+      devices {
+          # Device attributed for EMC CLARiiON and VNX/Unity series ALUA
+          device {
+              vendor "DGC"
+              product ".*"
+              product_blacklist "LUNZ"
+              path_grouping_policy group_by_prio
+              path_selector "round-robin 0"
+              path_checker emc_clariion
+              features "0"
+              no_path_retry 12
+              hardware_handler "1 alua"
+              prio alua
+              failback immediate
+          }
+      }
+
+
+#. Restart the multipath service:
+
+   .. code-block:: console
+
+      # service multipath-tools restart
+
+
+#. Enable multipath for image transfer in ``/etc/cinder/cinder.conf``.
+
+   .. code-block:: ini
+
+      use_multipath_for_image_xfer = True
+
+   Restart the ``cinder-volume`` service to load the change.
+
+#. Enable multipath for volume attache/detach in ``/etc/nova/nova.conf``.
+
+   .. code-block:: ini
+
+      [libvirt]
+      ...
+      volume_use_multipath = True
+      ...
+
+#. Restart the ``nova-compute`` service.
+
+Driver options
+~~~~~~~~~~~~~~
+
+.. include:: ../../tables/cinder-dell_emc_unity.inc
+
+FC or iSCSI ports option
+------------------------
+
+Specify the list of FC or iSCSI ports to be used to perform the IO. Wild card
+character is supported.
+For iSCSI ports, use the following format:
+
+.. code-block:: ini
+
+   unity_io_ports = spa_eth2, spb_eth2, *_eth3
+
+For FC ports, use the following format:
+
+.. code-block:: ini
+
+   unity_io_ports = spa_iom_0_fc0, spb_iom_0_fc0, *_iom_0_fc1
+
+List the port ID with the :command:`uemcli` command:
+
+.. code-block:: console
+
+   $ uemcli /net/port/eth show -output csv
+   ...
+   "spa_eth2","SP A Ethernet Port 2","spa","file, net, iscsi", ...
+   "spb_eth2","SP B Ethernet Port 2","spb","file, net, iscsi", ...
+   ...
+
+   $ uemcli /net/port/fc show -output csv
+   ...
+   "spa_iom_0_fc0","SP A I/O Module 0 FC Port 0","spa", ...
+   "spb_iom_0_fc0","SP B I/O Module 0 FC Port 0","spb", ...
+   ...
+
+Live migration integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is suggested to have multipath configured on Compute nodes for robust data
+access in VM instances live migration scenario. Once ``user_friendly_names no``
+is set in defaults section of ``/etc/multipath.conf``, Compute nodes will use
+the WWID as the alias for the multipath devices.
+
+To enable multipath in live migration:
+
+.. note:: Make sure `Driver configuration`_ steps are performed before
+          following steps.
+
+#. Set multipath in ``/etc/nova/nova.conf``:
+
+   .. code-block:: ini
+
+      [libvirt]
+      ...
+      volume_use_multipath = True
+      ...
+
+   Restart `nova-compute` service.
+
+
+#. Set ``user_friendly_names no`` in ``/etc/multipath.conf``
+
+   .. code-block:: text
+
+      ...
+      defaults {
+          user_friendly_names no
+      }
+      ...
+
+#. Restart the ``multipath-tools`` service.
+
+
+Thin and thick provisioning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the volume created by Unity driver is thin provisioned. Run the
+following commands to create a thick volume.
+
+.. code-block:: console
+
+    # openstack volume type create --property provisioning:type=thick \
+      --property thick_provisioning_support='<is> True' thick_volume_type
+    # openstack volume create --type thick_volume_type thick_volume
+
+
+QoS support
+~~~~~~~~~~~
+
+Unity driver supports ``maxBWS`` and ``maxIOPS`` specs for the back-end
+consumer type. ``maxBWS`` represents the ``Maximum IO/S`` absolute limit,
+``maxIOPS`` represents the ``Maximum Bandwidth (KBPS)`` absolute limit on the
+Unity respectively.
+
+
+Auto-zoning support
+~~~~~~~~~~~~~~~~~~~
+
+Unity volume driver supports auto-zoning, and share the same configuration
+guide for other vendors. Refer to :ref:`fc_zone_manager`
+for detailed configuration steps.
+
+Solution for LUNZ device
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The EMC host team also found LUNZ on all of the hosts, EMC best practice is to
+present a LUN with HLU 0 to clear any LUNZ devices as they can cause issues on
+the host. See KB `LUNZ Device <https://support.emc.com/kb/463402>`_.
+
+To workaround this issue, Unity driver creates a `Dummy LUN` (if not present),
+and adds it to each host to occupy the `HLU 0` during volume attachment.
+
+.. note:: This `Dummy LUN` is shared among all hosts connected to the Unity.
+
+Efficient non-disruptive volume backup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default implementation in Block Storage for non-disruptive volume backup is
+not efficient since a cloned volume will be created during backup.
+
+An effective approach to backups is to create a snapshot for the volume and
+connect this snapshot to the Block Storage host for volume backup.
+
+SSL support
+~~~~~~~~~~~
+
+Admin is able to enable the SSL verification for any communication against
+Unity REST API.
+
+By default, the SSL verification is disabled, user can enable it by following
+steps:
+
+#. Setup the Unity array certificate and import it to the Unity, see section
+   `Storage system certificate` of `Security Configuration Guide <https://www.emc.com/collateral/TechnicalDocument/docu69321.pdf>`_.
+
+#. Import the CA certficate to the Cinder nodes on which the driver is running.
+
+#. Enable the changes on cinder nodes and restart the cinder services.
+
+.. code-block:: ini
+
+     [unity]
+     ...
+     driver_ssl_cert_verify = True
+     driver_ssl_cert_path = <path to the CA>
+     ...
+
+
+If `driver_ssl_cert_path` is omitted, the system default CA will be used for CA
+verification.
+
+
+IPv6 support
+~~~~~~~~~~~~
+
+This driver can support IPv6-based control path and data path.
+
+For control path, please follow below steps:
+
+- Enable Unity's Unipshere IPv6 address.
+- Configure the IPv6 network to make sure that cinder node can access Unishpere
+  via IPv6 address.
+- Change Cinder config file ``/etc/cinder/cinder.conf``. Make the ``san_ip``
+  as Unisphere IPv6 address. For example, ``san_ip = [fd99:f17b:37d0::100]``.
+- Restart the Cinder service to make new configuration take effect.
+
+**Note**: The IPv6 support on control path depends on the fix of cpython
+`bug 32185 <https://bugs.python.org/issue32185>`__. Please make sure your
+Python's version includes this bug's fix.
+
+For data path, please follow below steps:
+
+- On Unity, Create iSCSI interface with IPv6 address.
+- Configure the IPv6 network to make sure that you can ``ping``
+  the Unity's iSCSI IPv6 address from the Cinder node.
+- If you create a volume using Cinder and attach it to a VM,
+  the connection between this VM and volume will be IPv6-based iSCSI.
+
+Force detach volume from all hosts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The user could use `os-force_detach` action to detach a volume from all its
+attached hosts.
+For more detail, please refer to
+https://developer.openstack.org/api-ref/block-storage/v2/?expanded=force-detach-volume-detail#force-detach-volume
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+To troubleshoot a failure in OpenStack deployment, the best way is to
+enable verbose and debug log, at the same time, leverage the build-in
+`Return request ID to caller
+<https://specs.openstack.org/openstack/openstack-specs/specs/return-request-id.html>`_
+to track specific Block Storage command logs.
+
+
+#. Enable verbose log, set following in ``/etc/cinder/cinder.conf`` and restart
+   all Block Storage services:
+
+   .. code-block:: ini
+
+      [DEFAULT]
+
+      ...
+
+      debug = True
+      verbose = True
+
+      ...
+
+
+   If other projects (usually Compute) are also involved, set `debug`
+   and ``verbose`` to ``True``.
+
+#. use ``--debug`` to trigger any problematic Block Storage operation:
+
+   .. code-block:: console
+
+      # cinder --debug create --name unity_vol1 100
+
+
+   You will see the request ID from the console, for example:
+
+   .. code-block:: console
+
+      DEBUG:keystoneauth:REQ: curl -g -i -X POST
+      http://192.168.1.9:8776/v2/e50d22bdb5a34078a8bfe7be89324078/volumes -H
+      "User-Agent: python-cinderclient" -H "Content-Type: application/json" -H
+      "Accept: application/json" -H "X-Auth-Token:
+      {SHA1}bf4a85ad64302b67a39ad7c6f695a9630f39ab0e" -d '{"volume": {"status":
+      "creating", "user_id": null, "name": "unity_vol1", "imageRef": null,
+      "availability_zone": null, "description": null, "multiattach": false,
+      "attach_status": "detached", "volume_type": null, "metadata": {},
+      "consistencygroup_id": null, "source_volid": null, "snapshot_id": null,
+      "project_id": null, "source_replica": null, "size": 10}}'
+      DEBUG:keystoneauth:RESP: [202] X-Compute-Request-Id:
+      req-3a459e0e-871a-49f9-9796-b63cc48b5015 Content-Type: application/json
+      Content-Length: 804 X-Openstack-Request-Id:
+      req-3a459e0e-871a-49f9-9796-b63cc48b5015 Date: Mon, 12 Dec 2016 09:31:44 GMT
+      Connection: keep-alive
+
+#. Use commands like ``grep``, ``awk`` to find the error related to the Block
+   Storage operations.
+
+   .. code-block:: console
+
+      # grep "req-3a459e0e-871a-49f9-9796-b63cc48b5015" cinder-volume.log
+

--- a/releasenotes/notes/unity-multiattach-support-993b997e522d9e84.yaml
+++ b/releasenotes/notes/unity-multiattach-support-993b997e522d9e84.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Dell EMC Unity: Implements `bp unity-multiattach-support
+    <https://blueprints.launchpad.net/cinder/+spec/unity-multiattach-support>`__
+    to support attaching a volume to multiple servers simultaneously.
+


### PR DESCRIPTION
Add the ability to attach a volume to multiple servers simultaneously.

After cherry-pick, increase the version to 3.3.0.

Implements: blueprint unity-multiattach-support

Change-Id: Ib7222bb3cd13505f9a8789f8cc85685e4ae9cce4
(cherry picked from commit dffff08a204ddf6416cd6ddb036e8e029dc80509)
(cherry picked from commit 5cb0f977e4a95860b261112a3c224daf0fdc6b58)