### PR TITLE
Unity: Enable ssl verification

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -43,7 +43,7 @@ class MockConfig(object):
         self.san_ip = '1.2.3.4'
         self.san_login = 'user'
         self.san_password = 'pass'
-        self.driver_ssl_cert_verify = False
+        self.driver_ssl_cert_verify = True
         self.driver_ssl_cert_path = None
         self.remove_empty_host = False
 
@@ -419,7 +419,7 @@ class CommonAdapterTest(unittest.TestCase):
         self.assertEqual('1.2.3.4', self.adapter.ip)
         self.assertEqual('user', self.adapter.username)
         self.assertEqual('pass', self.adapter.password)
-        self.assertFalse(self.adapter.array_cert_verify)
+        self.assertTrue(self.adapter.array_cert_verify)
         self.assertIsNone(self.adapter.array_ca_cert_path)
 
     def test_do_setup_version_before_4_1(self):

--- a/cinder/volume/drivers/dell_emc/unity/adapter.py
+++ b/cinder/volume/drivers/dell_emc/unity/adapter.py
@@ -153,9 +153,8 @@ class CommonAdapter(object):
         self.ip = self.config.san_ip
         self.username = self.config.san_login
         self.password = self.config.san_password
-        # Unity currently not support to upload certificate.
-        # Once it supports, enable the verify.
-        self.array_cert_verify = False
+        # Allow for customized CA
+        self.array_cert_verify = self.config.driver_ssl_cert_verify
         self.array_ca_cert_path = self.config.driver_ssl_cert_path
 
         sys_version = self.client.system.system_version

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -59,9 +59,10 @@ class UnityDriver(driver.ManageableVD,
         1.0.0 - Initial version
         2.0.0 - Add thin clone support
         2.1.0 - Cherry-pick the multi-attach support
+        2.2.0 - Enalbe SSL support
     """
 
-    VERSION = '02.01.00'
+    VERSION = '02.02.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
@@ -33,7 +33,6 @@ Supported operations
 - Get volume statistics.
 - Efficient non-disruptive volume backup.
 - Revert a volume to a snapshot.
-- Create thick volumes.
 - Attach a volume to multiple servers simultaneously (multiattach).
 
 Driver configuration
@@ -236,14 +235,7 @@ To enable multipath in live migration:
 Thin and thick provisioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the volume created by Unity driver is thin provisioned. Run the
-following commands to create a thick volume.
-
-.. code-block:: console
-
-    # openstack volume type create --property provisioning:type=thick \
-      --property thick_provisioning_support='<is> True' thick_volume_type
-    # openstack volume create --type thick_volume_type thick_volume
+Only thin volume provisioning is supported in Unity volume driver.
 
 
 QoS support

--- a/releasenotes/notes/unity-enable-ssl-14db2497225c4395.yaml
+++ b/releasenotes/notes/unity-enable-ssl-14db2497225c4395.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - Dell EMC Unity Cinder driver allows enabling/disabling the SSL verification.
+    Admin can set `True` or `False` for `driver_ssl_cert_verify` to enable
+    or disable this function, alternatively set the
+    `driver_ssl_cert_path=<PATH>` for customized CA path.
+    Both above 2 options should go under the driver section.


### PR DESCRIPTION
This commit allow user to enable ssl verification on demand for the
Unity Cinder driver.

Change-Id: Iaaa498a377edae873c489b6a5818923e16d594f0
(cherry picked from commit 8aa49599c7df62de5ab25a0a841265092e2881f7)
(cherry picked from commit 685de5a7b683552899fc0fd6c095d35b6a9bf555)