### PR TITLE
[Unity] Add support of removing empty host

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/fake_exception.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/fake_exception.py
@@ -72,3 +72,7 @@ class UnexpectedLunDeletion(Exception):
 
 class AdapterSetupError(Exception):
     pass
+
+
+class HostDeleteIsCalled(Exception):
+    pass

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -45,6 +45,7 @@ class MockConfig(object):
         self.san_password = 'pass'
         self.driver_ssl_cert_verify = True
         self.driver_ssl_cert_path = None
+        self.remove_empty_host = False
 
     def safe_get(self, name):
         return getattr(self, name)
@@ -70,6 +71,7 @@ class MockDriver(object):
 class MockClient(object):
     def __init__(self):
         self._system = test_client.MockSystem()
+        self.host = '10.10.10.10'  # fake unity IP
 
     @staticmethod
     def get_pools():
@@ -133,6 +135,15 @@ class MockClient(object):
     @staticmethod
     def create_host(name):
         return test_client.MockResource(name=name)
+
+    @staticmethod
+    def create_host_wo_lock(name):
+        return test_client.MockResource(name=name)
+
+    @staticmethod
+    def delete_host_wo_lock(host):
+        if host.name == 'empty-host':
+            raise ex.HostDeleteIsCalled()
 
     @staticmethod
     def attach(host, lun_or_snap):
@@ -472,6 +483,16 @@ class CommonAdapterTest(unittest.TestCase):
 
         self.assertRaises(ex.DetachIsCalled, f)
 
+    def test_terminate_connection_remove_empty_host(self):
+        self.adapter.remove_empty_host = True
+
+        def f():
+            connector = {'host': 'empty-host'}
+            vol = MockOSResource(provider_location='id^lun_45', id='id_45')
+            self.adapter.terminate_connection(vol, connector)
+
+        self.assertRaises(ex.HostDeleteIsCalled, f)
+
     def test_manage_existing_by_name(self):
         ref = {'source-id': 12}
         volume = MockOSResource(name='lun1')
@@ -783,6 +804,20 @@ class FCAdapterTest(unittest.TestCase):
 
     def test_terminate_connection_auto_zone_enabled(self):
         connector = {'host': 'host1', 'wwpns': 'abcdefg'}
+        volume = MockOSResource(provider_location='id^lun_41', id='id_41')
+        ret = self.adapter.terminate_connection(volume, connector)
+        self.assertEqual('fibre_channel', ret['driver_volume_type'])
+        data = ret['data']
+        target_map = {
+            '200000051e55a100': ('100000051e55a100', '100000051e55a121'),
+            '200000051e55a121': ('100000051e55a100', '100000051e55a121')}
+        self.assertDictEqual(target_map, data['initiator_target_map'])
+        target_wwn = ['100000051e55a100', '100000051e55a121']
+        self.assertListEqual(target_wwn, data['target_wwn'])
+
+    def test_terminate_connection_remove_empty_host_return_data(self):
+        self.adapter.remove_empty_host = True
+        connector = {'host': 'empty-host-return-data', 'wwpns': 'abcdefg'}
         volume = MockOSResource(provider_location='id^lun_41', id='id_41')
         ret = self.adapter.terminate_connection(volume, connector)
         self.assertEqual('fibre_channel', ret['driver_volume_type'])

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -66,6 +66,8 @@ class MockResource(object):
             raise ex.UnityResourceNotFoundError()
         elif self.get_id() == 'snap_in_use':
             raise ex.UnityDeleteAttachedSnapError()
+        elif self.name == 'empty-host':
+            raise ex.HostDeleteIsCalled()
 
     @property
     def pool(self):
@@ -534,3 +536,15 @@ class ClientTest(unittest.TestCase):
 
     def test_get_pool_name(self):
         self.assertEqual('Pool0', self.client.get_pool_name('lun_0'))
+
+    def test_delete_host_wo_lock(self):
+        host = MockResource(name='empty-host')
+        self.assertRaises(ex.HostDeleteIsCalled,
+                          self.client.delete_host_wo_lock,
+                          host)
+
+    def test_delete_host_wo_lock_remove_from_cache(self):
+        host = MockResource(name='empty-host-in-cache')
+        self.client.host_cache['empty-host-in-cache'] = host
+        self.client.delete_host_wo_lock(host)
+        self.assertNotIn(host.name, self.client.host_cache)

--- a/cinder/volume/drivers/dell_emc/unity/adapter.py
+++ b/cinder/volume/drivers/dell_emc/unity/adapter.py
@@ -139,6 +139,8 @@ class CommonAdapter(object):
         self.storage_pools_map = None
         self._client = None
         self.allowed_ports = None
+        self.remove_empty_host = False
+        self.to_lock_host = False
 
     def do_setup(self, driver, conf):
         self.driver = driver
@@ -166,6 +168,9 @@ class CommonAdapter(object):
 
         self.allowed_ports = self.validate_ports(self.config.unity_io_ports)
         coordination.COORDINATOR.start()
+
+        self.remove_empty_host = self.config.remove_empty_host
+        self.to_lock_host = self.remove_empty_host
 
         group_name = (self.config.config_group if self.config.config_group
                       else 'DEFAULT')
@@ -292,12 +297,26 @@ class CommonAdapter(object):
         else:
             self.client.delete_lun(lun_id)
 
+    def _create_host_and_attach(self, host_name, lun_or_snap):
+        @utils.lock_if(self.to_lock_host, '{lock_name}')
+        def _lock_helper(lock_name):
+            if not self.to_lock_host:
+                host = self.client.create_host(host_name)
+            else:
+                # use the lock in the decorator
+                host = self.client.create_host_wo_lock(host_name)
+            hlu = self.client.attach(host, lun_or_snap)
+            return host, hlu
+
+        return _lock_helper('{unity}-{host}'.format(unity=self.client.host,
+                                                    host=host_name))
+
     @cinder_utils.trace
     def _initialize_connection(self, lun_or_snap, connector, vol_id):
-        host = self.client.create_host(connector['host'])
+        host, hlu = self._create_host_and_attach(connector['host'],
+                                                 lun_or_snap)
         self.client.update_host_initiators(
             host, self.get_connector_uids(connector))
-        hlu = self.client.attach(host, lun_or_snap)
         data = self.get_connection_info(hlu, host, connector)
         data['target_discovered'] = True
         if vol_id is not None:
@@ -314,10 +333,34 @@ class CommonAdapter(object):
         lun = self.client.get_lun(lun_id=self.get_lun_id(volume))
         return self._initialize_connection(lun, connector, volume.id)
 
+    def _detach_and_delete_host(self, host_name, lun_or_snap):
+        @utils.lock_if(self.to_lock_host, '{lock_name}')
+        def _lock_helper(lock_name):
+            # Only get the host from cache here
+            host = self.client.create_host_wo_lock(host_name)
+            self.client.detach(host, lun_or_snap)
+            host.update()
+            if self.remove_empty_host and not host.host_luns:
+                self.client.delete_host_wo_lock(host)
+            return host.host_luns is None or len(host.host_luns) == 0
+
+        return _lock_helper('{unity}-{host}'.format(unity=self.client.host,
+                                                    host=host_name))
+
+    @staticmethod
+    def terminate_return_data(need_to_return, connector):
+        # No return data from terminate_connection for iSCSI driver
+        return None
+
     @cinder_utils.trace
     def _terminate_connection(self, lun_or_snap, connector):
-        host = self.client.create_host(connector['host'])
-        self.client.detach(host, lun_or_snap)
+        is_force_detach = connector is None
+        if is_force_detach:
+            self.client.detach_all(lun_or_snap)
+            return None
+        else:
+            flag = self._detach_and_delete_host(connector['host'], lun_or_snap)
+            return self.terminate_return_data(flag, connector)
 
     @cinder_utils.trace
     def terminate_connection(self, volume, connector):
@@ -735,24 +778,21 @@ class FCAdapter(CommonAdapter):
         return data
 
     @cinder_utils.trace
-    def _terminate_connection(self, lun_or_snap, connector):
+    def terminate_return_data(self, need_to_return, connector):
         # For FC, terminate_connection needs to return data to zone manager
         # which would clean the zone based on the data.
-        super(FCAdapter, self)._terminate_connection(lun_or_snap, connector)
-
-        ret = None
         if self.auto_zone_enabled:
             ret = {
                 'driver_volume_type': self.driver_volume_type,
                 'data': {}
             }
-            host = self.client.create_host(connector['host'])
-            if len(host.host_luns) == 0:
+            if need_to_return:
                 targets = self.client.get_fc_target_info(
                     logged_in_only=True, allowed_ports=self.allowed_ports)
                 ret['data'] = self._get_fc_zone_info(connector['wwpns'],
                                                      targets)
-        return ret
+            return ret
+        return None
 
     def _get_fc_zone_info(self, initiator_wwns, target_wwns):
         mapping = self.lookup_service.get_device_mapping_from_network(

--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -190,6 +190,9 @@ class UnityClient(object):
 
     @coordination.synchronized('{self.host}-{name}')
     def create_host(self, name):
+        return self.create_host_wo_lock(name)
+
+    def create_host_wo_lock(self, name):
         """Provides existing host if exists else create one."""
         if name not in self.host_cache:
             try:
@@ -203,6 +206,10 @@ class UnityClient(object):
         else:
             host = self.host_cache[name]
         return host
+
+    def delete_host_wo_lock(self, host):
+        host.delete()
+        del self.host_cache[host.name]
 
     def update_host_initiators(self, host, uids):
         """Updates host with the supplied uids."""

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -41,7 +41,11 @@ UNITY_OPTS = [
     cfg.ListOpt('unity_io_ports',
                 default=None,
                 help='A comma-separated list of iSCSI or FC ports to be used. '
-                     'Each port can be Unix-style glob expressions.')]
+                     'Each port can be Unix-style glob expressions.'),
+    cfg.BoolOpt('remove_empty_host',
+                default=False,
+                help='To remove the host from Unity when the last LUN is '
+                     'detached from it. By default, it is False.')]
 
 CONF.register_opts(UNITY_OPTS)
 
@@ -53,6 +57,7 @@ class UnityDriver(driver.TransferVD,
     """Unity Driver.
 
     Version history:
+        00.04.09 - Support of removing empty host
         00.04.08 - Enalbe SSL support
         00.04.07 - Fixed bug which create volume related logs failed to print
         00.04.06 - Backport thin clone from Newton
@@ -63,7 +68,7 @@ class UnityDriver(driver.TransferVD,
         00.04.02 - Initial version
     """
 
-    VERSION = '00.04.08'
+    VERSION = '00.04.09'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/cinder/volume/drivers/dell_emc/unity/utils.py
+++ b/cinder/volume/drivers/dell_emc/unity/utils.py
@@ -23,6 +23,7 @@ from oslo_utils import fnmatch
 from oslo_utils import units
 import six
 
+from cinder import coordination
 from cinder import exception
 from cinder.i18n import _, _LW
 from cinder.volume import utils as vol_utils
@@ -289,3 +290,10 @@ def match_any(full, patterns):
 
 def is_before_4_1(ver):
     return version.LooseVersion(ver) < version.LooseVersion('4.1')
+
+
+def lock_if(condition, lock_name):
+    if condition:
+        return coordination.synchronized(lock_name)
+    else:
+        return functools.partial


### PR DESCRIPTION
Add an option in Unity Cinder driver to customize the removing
of empty host. The option is named `remove_empty_host`. It's
default value is False. When it is set to True, the host will
be removed from Unity after the last LUN is detached from it.

Change-Id: I2d9fad2c977a61f5b26a6449a8e509911eff28e0
(cherry picked from commit 89c28030f6e5d03ebc4c48aac6332fd8439e8c3d)
(cherry picked from commit 3b7f3fb5a455d87127006a61ee593d5ee6cac74e)