### PR TITLE
[Unity]: delete lun with hosts accessed

### DIFF
--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -111,6 +111,13 @@ class UnityClient(object):
         def _delete_lun_if_exist(force_snap_delete=False):
             """Deletes LUN, skip if it doesn't exist."""
             try:
+                if hasattr(lun, 'host_access') and lun.host_access:
+                    LOG.info("LUN %(id)s has hosts accessed, hosts: "
+                             "%(hosts)s, remove these accesses anyway.",
+                             {'id': lun_id,
+                              'hosts': [host_access.host.name for host_access
+                                        in lun.host_access]})
+                    lun.modify(host_access=[])
                 lun.delete(force_snap_delete=force_snap_delete)
             except storops_ex.UnityResourceNotFoundError:
                 LOG.debug("LUN %s doesn't exist. Deletion is not needed.",

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -83,9 +83,11 @@ class UnityDriver(driver.ManageableVD,
         6.0.0 - Support generic group and consistent group
         6.1.0 - Support volume replication
         6.2.0 - Support new QoS keys
+        6.3.0 - Fixes bug 1879705 to make sure lun could be deleted
+                even though the lun has hosts accessed.
     """
 
-    VERSION = '06.02.00'
+    VERSION = '06.03.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"


### PR DESCRIPTION
If lun in Unity backend has hosts accessed, it can't be deleted.
It will cause volume failed to delete in OpenStack.
So remove host access before lun deletion.

Change-Id: I0887f48c28741f434c6a48041c87e849e471bb94
Closes-bug: #1879705
(cherry picked from commit ead6bf08203f37c309043e43f8edbe2736ebacc9)