### PR TITLE
[Unity]: Supports QoS keys 'total_iops_sec' and 'total_bytes_sec' (#19)

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -269,6 +269,20 @@ def get_connection_info(adapter, hlu, host, connector):
     return {}
 
 
+def get_volume_type_qos_specs(qos_id):
+    if qos_id == 'qos':
+        return {'qos_specs': {'id': u'qos_type_id_1',
+                              'consumer': u'back-end',
+                              u'qos_bws': u'102400',
+                              u'qos_iops': u'500'}}
+    if qos_id == 'qos_2':
+        return {'qos_specs': {'id': u'qos_type_id_2',
+                              'consumer': u'back-end',
+                              u'qos_bws': u'102402',
+                              u'qos_iops': u'502'}}
+    return {'qos_specs': {}}
+
+
 def patch_for_unity_adapter(func):
     @functools.wraps(func)
     @mock.patch('cinder.volume.drivers.dell_emc.unity.utils.'

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -513,7 +513,7 @@ class ClientTest(unittest.TestCase):
         self.assertIsNone(ret)
 
     def test_get_io_limit_policy_create_new(self):
-        specs = {'maxBWS': 2, 'id': 'max_2_mbps', 'maxIOPS': None}
+        specs = {'qos_bws': 2, 'id': 'max_2_mbps', 'qos_iops': None}
         limit = self.client.get_io_limit_policy(specs)
         self.assertEqual('max_2_mbps', limit.name)
         self.assertEqual(2, limit.max_kbps)

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
@@ -43,6 +43,16 @@ def get_volume_type_qos_specs(type_id):
                 }
             }
         }
+    elif type_id == 'max_1001_iops':
+        ret = {
+            'qos_specs': {
+                'id': 'max_1001_iops',
+                'consumer': 'both',
+                'specs': {
+                    'total_iops_sec': 1001
+                }
+            }
+        }
     elif type_id == 'max_2_mbps':
         ret = {
             'qos_specs': {
@@ -50,6 +60,29 @@ def get_volume_type_qos_specs(type_id):
                 'consumer': 'back-end',
                 'specs': {
                     'maxBWS': 2
+                }
+            }
+        }
+    elif type_id == 'max_3_mbps':
+        ret = {
+            'qos_specs': {
+                'id': 'max_3_mbps',
+                'consumer': 'back-end',
+                'specs': {
+                    'total_bytes_sec': 3
+                }
+            }
+        }
+    elif type_id == 'qos_mix_keys':
+        ret = {
+            'qos_specs': {
+                'id': 'max_3_mbps',
+                'consumer': 'back-end',
+                'specs': {
+                    'maxIOPS': 1000,
+                    'total_iops_sec': 1001,
+                    'maxBWS': 2,
+                    'total_bytes_sec': 3
                 }
             }
         }
@@ -242,15 +275,36 @@ class UnityUtilsTest(unittest.TestCase):
         self.assertIsNone(ret)
 
     @patch_volume_types
-    def test_get_backend_qos_iops(self):
+    def test_get_backend_qos_iops_old_keys(self):
         volume = test_adapter.MockOSResource(volume_type_id='max_1000_iops')
         ret = utils.get_backend_qos_specs(volume)
-        expected = {'maxBWS': None, 'id': 'max_1000_iops', 'maxIOPS': 1000}
+        expected = {'qos_bws': None, 'id': 'max_1000_iops', 'qos_iops': 1000}
         self.assertEqual(expected, ret)
 
     @patch_volume_types
-    def test_get_backend_qos_mbps(self):
+    def test_get_backend_qos_iops_new_keys(self):
+        volume = test_adapter.MockOSResource(volume_type_id='max_1001_iops')
+        ret = utils.get_backend_qos_specs(volume)
+        expected = {'qos_bws': None, 'id': 'max_1001_iops', 'qos_iops': 1001}
+        self.assertEqual(expected, ret)
+
+    @patch_volume_types
+    def test_get_backend_qos_mbps_old_keys(self):
         volume = test_adapter.MockOSResource(volume_type_id='max_2_mbps')
         ret = utils.get_backend_qos_specs(volume)
-        expected = {'maxBWS': 2, 'id': 'max_2_mbps', 'maxIOPS': None}
+        expected = {'qos_bws': 2, 'id': 'max_2_mbps', 'qos_iops': None}
+        self.assertEqual(expected, ret)
+
+    @patch_volume_types
+    def test_get_backend_qos_mbps_new_keys(self):
+        volume = test_adapter.MockOSResource(volume_type_id='max_3_mbps')
+        ret = utils.get_backend_qos_specs(volume)
+        expected = {'qos_bws': 3, 'id': 'max_3_mbps', 'qos_iops': None}
+        self.assertEqual(expected, ret)
+
+    @patch_volume_types
+    def test_get_backend_qos_mix_keys(self):
+        volume = test_adapter.MockOSResource(volume_type_id='qos_mix_keys')
+        ret = utils.get_backend_qos_specs(volume)
+        expected = {'qos_bws': 3, 'id': 'max_3_mbps', 'qos_iops': 1001}
         self.assertEqual(expected, ret)

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -52,17 +52,17 @@ class UnityDriver(driver.ManageableVD,
                   driver.BaseVD):
     """Unity Driver.
 
-    Version history:
-
     .. code-block:: none
 
+      Version history:
         1.0.0 - Initial version
         2.0.0 - Add thin clone support
         2.1.0 - Cherry-pick the multi-attach support
         2.2.0 - Enalbe SSL support
+        2.3.0 - Support new QoS keys (cherry pick from downstream train)
     """
 
-    VERSION = '02.02.00'
+    VERSION = '02.03.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/cinder/volume/drivers/dell_emc/unity/utils.py
+++ b/cinder/volume/drivers/dell_emc/unity/utils.py
@@ -33,8 +33,8 @@ from cinder.zonemanager import utils as zm_utils
 
 LOG = logging.getLogger(__name__)
 BACKEND_QOS_CONSUMERS = frozenset(['back-end', 'both'])
-QOS_MAX_IOPS = 'maxIOPS'
-QOS_MAX_BWS = 'maxBWS'
+QOS_MAX_IOPS = 'qos_iops'
+QOS_MAX_BWS = 'qos_bws'
 
 
 def dump_provider_location(location_dict):
@@ -258,8 +258,9 @@ def get_backend_qos_specs(volume):
     if consumer not in BACKEND_QOS_CONSUMERS:
         return None
 
-    max_iops = qos_specs['specs'].get(QOS_MAX_IOPS)
-    max_bws = qos_specs['specs'].get(QOS_MAX_BWS)
+    specs = qos_specs['specs']
+    max_iops = specs.get('total_iops_sec') or specs.get('maxIOPS')
+    max_bws = specs.get('total_bytes_sec') or specs.get('maxBWS')
     if max_iops is None and max_bws is None:
         return None
 

--- a/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
@@ -241,10 +241,11 @@ Only thin volume provisioning is supported in Unity volume driver.
 QoS support
 ~~~~~~~~~~~
 
-Unity driver supports ``maxBWS`` and ``maxIOPS`` specs for the back-end
-consumer type. ``maxBWS`` represents the ``Maximum IO/S`` absolute limit,
-``maxIOPS`` represents the ``Maximum Bandwidth (KBPS)`` absolute limit on the
-Unity respectively.
+Unity driver supports ``total_bytes_sec``/``maxBWS`` and ``total_iops_sec``/
+``maxIOPS`` for the back-end consumer type.
+``total_bytes_sec``/``maxBWS`` represents the ``Maximum Bandwidth (KBPS)``
+absolute limit and ``total_iops_sec``/``maxIOPS`` represents the
+``Maximum IO/S`` absolute limit on the Unity respectively.
 
 
 Auto-zoning support


### PR DESCRIPTION
Supports QoS keys 'total_iops_sec' and 'total_bytes_sec'.

Change-Id: Ieb9438ccb42465d67a0d41588877403323a23b16
Closes-bug: #1875324
(cherry picked from commit 95dca32e96d7238cb6081b369fa9d3dd81f669e1)
(cherry picked from commit ed2c442bb893a2dfa4eea09ebbedd261671f5729)