### PR TITLE
Unity: add multiattach support (#18)

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/fake_exception.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/fake_exception.py
@@ -58,6 +58,10 @@ class DetachIsCalled(Exception):
     pass
 
 
+class DetachAllIsCalled(Exception):
+    pass
+
+
 class LunDeleteIsCalled(Exception):
     pass
 

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -57,6 +57,7 @@ class UnityDriver(driver.TransferVD,
     """Unity Driver.
 
     Version history:
+        00.04.12 - Support multi-attach (cherry-pick from downstream pike)
         00.04.11 - Fixes bug 1879705 to make sure lun could be deleted even
                    though the lun has hosts accessed. (cherry pick from
                    downstream pike)
@@ -67,12 +68,12 @@ class UnityDriver(driver.TransferVD,
         00.04.06 - Backport thin clone from Newton
         00.04.05 - Fix Coordinator uninitialized issue
         00.04.04 - Fix duplicate hosts created with same name (cherry-pick from
-                   downstream Newton
+                   downstream newton)
         00.04.03 - Add TransferVD to base, and fix version number
         00.04.02 - Initial version
     """
 
-    VERSION = '00.04.11'
+    VERSION = '00.04.12'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/cinder/volume/drivers/dell_emc/unity/utils.py
+++ b/cinder/volume/drivers/dell_emc/unity/utils.py
@@ -298,3 +298,18 @@ def lock_if(condition, lock_name):
         return coordination.synchronized(lock_name)
     else:
         return functools.partial
+
+
+def is_multiattach_to_host(volume_attachment, host_name):
+    # When multiattach is enabled, a volume could be attached to two or more
+    # instances which are hosted on one nova host.
+    # Because unity cannot recognize the volume is attached to two or more
+    # instances, we should keep the volume attached to the nova host until
+    # the volume is detached from the last instance.
+    if not volume_attachment:
+        return False
+
+    attachment = [a for a in volume_attachment
+                  if a.attach_status == 'attached' and
+                  a.attached_host == host_name]
+    return len(attachment) > 1

--- a/releasenotes/notes/unity-multiattach-support-993b997e522d9e84.yaml
+++ b/releasenotes/notes/unity-multiattach-support-993b997e522d9e84.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Dell EMC Unity: Implements `bp unity-multiattach-support
+    <https://blueprints.launchpad.net/cinder/+spec/unity-multiattach-support>`__
+    to support attaching a volume to multiple servers simultaneously.
+


### PR DESCRIPTION
Add the ability to attach a volume to multiple servers simultaneously.

After cherry-pick, increase the version to 00.04.10.

Implements: blueprint unity-multiattach-support

Change-Id: Ib7222bb3cd13505f9a8789f8cc85685e4ae9cce4
(cherry picked from commit dffff08a204ddf6416cd6ddb036e8e029dc80509)
(cherry picked from commit 5cb0f977e4a95860b261112a3c224daf0fdc6b58)
(cherry picked from commit 5d5c956e04a6b99c3b27eee1bfb8c1a72f34731b)

Co-authored-by: Ryan Liang <ryan.liang@dell.com>