### PR TITLE
[Unity]: delete lun with hosts accessed (#23)

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -239,6 +239,14 @@ class MockSystem(object):
             lun = MockResource(name=_id, _id=_id)
             lun.total_size_gb = 7
             return lun
+        if _id == 'lun_host_attached':
+            lun = MockResource(name=_id, _id=_id)
+            host_access_1 = MockResource(_id='host_access_1')
+            host_access_1.host = MockResource(name='host_1', _id='host_1')
+            host_access_2 = MockResource(_id='host_access_2')
+            host_access_2.host = MockResource(name='host_2', _id='host_2')
+            lun.host_access = [host_access_1, host_access_2]
+            return lun
         return MockResource(name, _id)
 
     @staticmethod
@@ -362,6 +370,22 @@ class ClientTest(unittest.TestCase):
             self.client.delete_lun('not_found')
         except ex.StoropsException:
             self.fail('not found error should be dealt with silently.')
+
+    def test_delete_lun_with_host_attached(self):
+        lun = self.client.system.get_lun(_id='lun_host_attached')
+
+        def lun_modify(host_access):
+            lun.host_access = host_access
+
+        lun.modify = mock.MagicMock(side_effect=lun_modify)
+
+        with mock.patch.object(client, 'storops', new='True'):
+            unity_client = client.UnityClient('1.2.3.4', 'user', 'pass')
+            unity_client._system = mock.MagicMock()
+            unity_client._system.get_lun.return_value = lun
+            unity_client.delete_lun('lun_host_attached')
+            lun.modify.assert_called_with(host_access=[])
+            self.assertEqual([], lun.host_access)
 
     def test_get_lun_with_id(self):
         lun = self.client.get_lun('lun4')
@@ -540,6 +564,7 @@ class ClientTest(unittest.TestCase):
 
     def test_delete_host_wo_lock(self):
         host = MockResource(name='empty-host')
+        self.client.host_cache['empty-host'] = host
         self.assertRaises(ex.HostDeleteIsCalled,
                           self.client.delete_host_wo_lock,
                           host)

--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -98,10 +98,26 @@ class UnityClient(object):
         """
         try:
             lun = self.system.get_lun(_id=lun_id)
-            lun.delete()
         except storops_ex.UnityResourceNotFoundError:
-            LOG.debug("LUN %s doesn't exist. Deletion is not needed.",
-                      lun_id)
+            LOG.debug("Cannot get LUN %s from unity. Do nothing.", lun_id)
+            return
+
+        def _delete_lun_if_exist():
+            """Deletes LUN, skip if it doesn't exist."""
+            try:
+                if hasattr(lun, 'host_access') and lun.host_access:
+                    LOG.info("LUN %(id)s has hosts accessed, hosts: "
+                             "%(hosts)s, remove these accesses anyway.",
+                             {'id': lun_id,
+                              'hosts': [host_access.host.name for host_access
+                                        in lun.host_access]})
+                    lun.modify(host_access=[])
+                lun.delete()
+            except storops_ex.UnityResourceNotFoundError:
+                LOG.debug("LUN %s doesn't exist. Deletion is not needed.",
+                          lun_id)
+
+        _delete_lun_if_exist()
 
     def get_lun(self, lun_id=None, name=None):
         """Gets LUN on the Unity system.

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -60,9 +60,12 @@ class UnityDriver(driver.ManageableVD,
         2.1.0 - Cherry-pick the multi-attach support
         2.2.0 - Enalbe SSL support
         2.3.0 - Support new QoS keys (cherry pick from downstream train)
+        2.4.0 - Fixes bug 1879705 to make sure lun could be deleted even
+                though the lun has hosts accessed. (cherry pick from
+                downstream train)
     """
 
-    VERSION = '02.03.00'
+    VERSION = '02.04.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"


### PR DESCRIPTION
If lun in Unity backend has hosts accessed, it can't be deleted.
It will cause volume failed to delete in OpenStack.
So remove host access before lun deletion.

Change-Id: I0887f48c28741f434c6a48041c87e849e471bb94
Closes-bug: #1879705
(cherry picked from commit ead6bf08203f37c309043e43f8edbe2736ebacc9)
(cherry picked from commit e647c40dbd28ad21105cc9acda9daa3aee257b2a)