### PR TITLE
[Unity]: delete lun with hosts accessed (#23) (#28)

### DIFF
--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -100,10 +100,26 @@ class UnityClient(object):
         """
         try:
             lun = self.system.get_lun(_id=lun_id)
-            lun.delete()
         except storops_ex.UnityResourceNotFoundError:
-            LOG.debug("LUN %s doesn't exist. Deletion is not needed.",
-                      lun_id)
+            LOG.debug("Cannot get LUN %s from unity. Do nothing.", lun_id)
+            return
+
+        def _delete_lun_if_exist():
+            """Deletes LUN, skip if it doesn't exist."""
+            try:
+                if hasattr(lun, 'host_access') and lun.host_access:
+                    LOG.info("LUN %(id)s has hosts accessed, hosts: "
+                             "%(hosts)s, remove these accesses anyway.",
+                             {'id': lun_id,
+                              'hosts': [host_access.host.name for host_access
+                                        in lun.host_access]})
+                    lun.modify(host_access=[])
+                lun.delete()
+            except storops_ex.UnityResourceNotFoundError:
+                LOG.debug("LUN %s doesn't exist. Deletion is not needed.",
+                          lun_id)
+
+        _delete_lun_if_exist()
 
     def get_lun(self, lun_id=None, name=None):
         """Gets LUN on the Unity system.

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -57,6 +57,9 @@ class UnityDriver(driver.TransferVD,
     """Unity Driver.
 
     Version history:
+        00.04.11 - Fixes bug 1879705 to make sure lun could be deleted even
+                   though the lun has hosts accessed. (cherry pick from
+                   downstream pike)
         00.04.10 - Support new QoS keys (cherry pick from downstream pike)
         00.04.09 - Support of removing empty host
         00.04.08 - Enalbe SSL support
@@ -69,7 +72,7 @@ class UnityDriver(driver.TransferVD,
         00.04.02 - Initial version
     """
 
-    VERSION = '00.04.10'
+    VERSION = '00.04.11'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"


### PR DESCRIPTION
If lun in Unity backend has hosts accessed, it can't be deleted.
It will cause volume failed to delete in OpenStack.
So remove host access before lun deletion.

Change-Id: I0887f48c28741f434c6a48041c87e849e471bb94
Closes-bug: #1879705
(cherry picked from commit ead6bf08203f37c309043e43f8edbe2736ebacc9)
(cherry picked from commit e647c40dbd28ad21105cc9acda9daa3aee257b2a)
(cherry picked from commit d9854351a77b5132cb99a979b97eeb5d899b3218)