### PR TITLE
[Unity]: Convert total_bytes_sec value to KBPS

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
@@ -53,36 +53,46 @@ def get_volume_type_qos_specs(type_id):
                 }
             }
         }
-    elif type_id == 'max_2_mbps':
+    elif type_id == 'max_2_kbps':
         ret = {
             'qos_specs': {
-                'id': 'max_2_mbps',
+                'id': 'max_2_kbps',
                 'consumer': 'back-end',
                 'specs': {
                     'maxBWS': 2
                 }
             }
         }
-    elif type_id == 'max_3_mbps':
+    elif type_id == 'max_3_kbps':
         ret = {
             'qos_specs': {
-                'id': 'max_3_mbps',
+                'id': 'max_3_kbps',
                 'consumer': 'back-end',
                 'specs': {
-                    'total_bytes_sec': 3
+                    'total_bytes_sec': 3072
                 }
             }
         }
     elif type_id == 'qos_mix_keys':
         ret = {
             'qos_specs': {
-                'id': 'max_3_mbps',
+                'id': 'qos_mix_keys',
                 'consumer': 'back-end',
                 'specs': {
                     'maxIOPS': 1000,
                     'total_iops_sec': 1001,
-                    'maxBWS': 2,
-                    'total_bytes_sec': 3
+                    'maxBWS': 1000,
+                    'total_bytes_sec': 1025024
+                }
+            }
+        }
+    elif type_id == 'qos_bps_frac':
+        ret = {
+            'qos_specs': {
+                'id': 'qos_bps_frac',
+                'consumer': 'back-end',
+                'specs': {
+                    'total_bytes_sec': 1025000000
                 }
             }
         }
@@ -308,24 +318,31 @@ class UnityUtilsTest(unittest.TestCase):
         self.assertEqual(expected, ret)
 
     @patch_volume_types
-    def test_get_backend_qos_mbps_old_keys(self):
-        volume = test_adapter.MockOSResource(volume_type_id='max_2_mbps')
+    def test_get_backend_qos_bps_old_keys(self):
+        volume = test_adapter.MockOSResource(volume_type_id='max_2_kbps')
         ret = utils.get_backend_qos_specs(volume)
-        expected = {'qos_bws': 2, 'id': 'max_2_mbps', 'qos_iops': None}
+        expected = {'qos_bws': 2, 'id': 'max_2_kbps', 'qos_iops': None}
         self.assertEqual(expected, ret)
 
     @patch_volume_types
-    def test_get_backend_qos_mbps_new_keys(self):
-        volume = test_adapter.MockOSResource(volume_type_id='max_3_mbps')
+    def test_get_backend_qos_bps_new_keys(self):
+        volume = test_adapter.MockOSResource(volume_type_id='max_3_kbps')
         ret = utils.get_backend_qos_specs(volume)
-        expected = {'qos_bws': 3, 'id': 'max_3_mbps', 'qos_iops': None}
+        expected = {'qos_bws': 3, 'id': 'max_3_kbps', 'qos_iops': None}
+        self.assertEqual(expected, ret)
+
+    @patch_volume_types
+    def test_get_backend_qos_bps_new_keys_frac(self):
+        volume = test_adapter.MockOSResource(volume_type_id='qos_bps_frac')
+        ret = utils.get_backend_qos_specs(volume)
+        expected = {'qos_bws': 1000976, 'id': 'qos_bps_frac', 'qos_iops': None}
         self.assertEqual(expected, ret)
 
     @patch_volume_types
     def test_get_backend_qos_mix_keys(self):
         volume = test_adapter.MockOSResource(volume_type_id='qos_mix_keys')
         ret = utils.get_backend_qos_specs(volume)
-        expected = {'qos_bws': 3, 'id': 'max_3_mbps', 'qos_iops': 1001}
+        expected = {'qos_bws': 1001, 'id': 'qos_mix_keys', 'qos_iops': 1001}
         self.assertEqual(expected, ret)
 
     def test_remove_empty(self):

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -85,9 +85,11 @@ class UnityDriver(driver.ManageableVD,
         6.2.0 - Support new QoS keys
         6.3.0 - Fixes bug 1879705 to make sure lun could be deleted
                 even though the lun has hosts accessed.
+        6.4.0 - Fixes bug 1883677 to convert the value of total_bytes_sec
+                to KBPS to set correct bandwidth
     """
 
-    VERSION = '06.03.00'
+    VERSION = '06.04.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/cinder/volume/drivers/dell_emc/unity/utils.py
+++ b/cinder/volume/drivers/dell_emc/unity/utils.py
@@ -277,7 +277,8 @@ def get_backend_qos_specs(volume):
 
     specs = qos_specs['specs']
     max_iops = specs.get('total_iops_sec') or specs.get('maxIOPS')
-    max_bws = specs.get('total_bytes_sec') or specs.get('maxBWS')
+    max_bps = specs.get('total_bytes_sec')
+    max_bws = int(max_bps) // 1024 if max_bps else specs.get('maxBWS')
     if max_iops is None and max_bws is None:
         return None
 

--- a/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
@@ -297,9 +297,13 @@ QoS support
 
 Unity driver supports ``total_bytes_sec``/``maxBWS`` and ``total_iops_sec``/
 ``maxIOPS`` for the back-end consumer type.
-``total_bytes_sec``/``maxBWS`` represents the ``Maximum Bandwidth (KBPS)``
-absolute limit and ``total_iops_sec``/``maxIOPS`` represents the
-``Maximum IO/S`` absolute limit on the Unity respectively.
+``total_bytes_sec`` represents the ``Maximum Bandwidth in Bytes`` absolute
+limit while ``maxBWS`` represents the ``Maximum Bandwidth in KB`` absolute
+limit and ``total_iops_sec``/``maxIOPS`` represents the ``Maximum IO/S``
+absolute limit on the Unity respectively.
+If ``total_iops_sec``, ``maxIOPS``, ``total_bytes_sec`` and ``maxBWS`` are
+set at the same time, ``total_iops_sec`` and ``total_bytes_sec`` will be
+chosen.
 
 
 Auto-zoning support


### PR DESCRIPTION
The unit of total_bytes_sec is Bytes and the unit of bandwidth in
Unity is KBPS, so convert the value of total_bytes_sec to KBPS to
fit Unity requirement.

Change-Id: Ica9574f96062e32f7fe13c86fcea4675e17fd435