### PR TITLE
[Unity] Storage-assisted migration support

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -215,6 +215,18 @@ class MockClient(object):
     def system(self):
         return self._system
 
+    def get_pool_id_by_name(self, name):
+        pools = {'PoolA': 'pool_1',
+                 'PoolB': 'pool_2',
+                 'PoolC': 'pool_3'}
+        return pools.get(name, None)
+
+    def migrate_lun(self, lun_id, dest_pool_id):
+        if dest_pool_id == 'pool_2':
+            return True
+        if dest_pool_id == 'pool_3':
+            return False
+
 
 class MockLookupService(object):
     @staticmethod
@@ -800,6 +812,38 @@ class CommonAdapterTest(unittest.TestCase):
             config = MockConfig()
             config.unity_io_ports = ['', '   ']
             self.adapter.normalize_config(config)
+
+    def test_get_pool_id_by_name(self):
+        pool_name = 'PoolA'
+        pool_id = self.adapter.get_pool_id_by_name(pool_name)
+        self.assertEqual('pool_1', pool_id)
+
+    def test_migrate_volume(self):
+        provider_location = 'id^1|system^FNM001|type^lun|version^05.00'
+        volume = MockOSResource(id='1', name='vol_1',
+                                host='HostA@BackendB#PoolA',
+                                provider_location=provider_location)
+        host = {'host': 'HostA@BackendB#PoolB'}
+        ret = self.adapter.migrate_volume(volume, host)
+        self.assertEqual((True, {}), ret)
+
+    def test_migrate_volume_failed(self):
+        provider_location = 'id^1|system^FNM001|type^lun|version^05.00'
+        volume = MockOSResource(id='1', name='vol_1',
+                                host='HostA@BackendB#PoolA',
+                                provider_location=provider_location)
+        host = {'host': 'HostA@BackendB#PoolC'}
+        ret = self.adapter.migrate_volume(volume, host)
+        self.assertEqual((False, None), ret)
+
+    def test_migrate_volume_cross_backends(self):
+        provider_location = 'id^1|system^FNM001|type^lun|version^05.00'
+        volume = MockOSResource(id='1', name='vol_1',
+                                host='HostA@BackendA#PoolA',
+                                provider_location=provider_location)
+        host = {'host': 'HostA@BackendB#PoolB'}
+        ret = self.adapter.migrate_volume(volume, host)
+        self.assertEqual((False, None), ret)
 
 
 class FCAdapterTest(unittest.TestCase):

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -186,6 +186,11 @@ class MockResource(object):
             raise ex.UnityLunNameInUseError
         return MockResource(_id=name, name=name)
 
+    def migrate(self, dest_pool):
+        if dest_pool.id == 'pool_2':
+            return False
+        return True
+
 
 class MockResourceList(object):
     def __init__(self, names=None, ids=None):
@@ -250,7 +255,11 @@ class MockSystem(object):
         return MockResource(name, _id)
 
     @staticmethod
-    def get_pool():
+    def get_pool(_id=None, name=None):
+        if name == 'Pool 3':
+            return MockResource(name, 'pool_3')
+        if name or _id:
+            return MockResource(name, _id)
         return MockResourceList(['Pool 1', 'Pool 2'])
 
     @staticmethod
@@ -558,6 +567,17 @@ class ClientTest(unittest.TestCase):
     def test_expand_lun_nothing_to_modify(self):
         lun = self.client.extend_lun('ev_4', 5)
         self.assertEqual(5, lun.total_size_gb)
+
+    def test_migrate_lun_success(self):
+        ret = self.client.migrate_lun('lun_0', 'pool_1')
+        self.assertTrue(ret)
+
+    def test_migrate_lun_failed(self):
+        ret = self.client.migrate_lun('lun_0', 'pool_2')
+        self.assertFalse(ret)
+
+    def test_get_pool_id_by_name(self):
+        self.assertEqual('pool_3', self.client.get_pool_id_by_name('Pool 3'))
 
     def test_get_pool_name(self):
         self.assertEqual('Pool0', self.client.get_pool_name('lun_0'))

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_driver.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_driver.py
@@ -97,6 +97,11 @@ class MockAdapter(object):
         return {'snapshot': snapshot, 'connector': connector}
 
 
+    @staticmethod
+    def migrate_volume(volume, host):
+        return True, {}
+
+
 ########################
 #
 #   Start of Tests
@@ -179,6 +184,13 @@ class UnityDriverTest(unittest.TestCase):
         volume = self.get_volume()
         self.driver.delete_volume(volume)
         self.assertFalse(volume.exists)
+
+    def test_migrate_volume(self):
+        volume = self.get_volume()
+        ret = self.driver.migrate_volume(self.get_context(),
+                                         volume,
+                                         'HostA@BackendB#PoolC')
+        self.assertEqual((True, {}), ret)
 
     def test_create_snapshot(self):
         snapshot = self.get_snapshot()

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
@@ -232,6 +232,21 @@ class UnityUtilsTest(unittest.TestCase):
         volume = test_adapter.MockOSResource(host='host@backend#pool_name')
         self.assertEqual('pool_name', utils.get_pool_name(volume))
 
+    def test_get_pool_name_from_host(self):
+        host = {'host': 'host@backend#pool_name'}
+        ret = utils.get_pool_name_from_host(host)
+        self.assertEqual('pool_name', ret)
+
+    def get_backend_name_from_volume(self):
+        volume = test_adapter.MockOSResource(host='host@backend#pool_name')
+        ret = utils.get_backend_name_from_volume(volume)
+        self.assertEqual('host@backend', ret)
+
+    def get_backend_name_from_host(self):
+        host = {'host': 'host@backend#pool_name'}
+        ret = utils.get_backend_name_from_volume(host)
+        self.assertEqual('host@backend', ret)
+
     def test_ignore_exception(self):
         class IgnoredException(Exception):
             pass

--- a/cinder/volume/drivers/dell_emc/unity/adapter.py
+++ b/cinder/volume/drivers/dell_emc/unity/adapter.py
@@ -764,6 +764,9 @@ class CommonAdapter(object):
     def get_pool_name(self, volume):
         return self.client.get_pool_name(volume.name)
 
+    def get_pool_id_by_name(self, name):
+        return self.client.get_pool_id_by_name(name=name)
+
     @cinder_utils.trace
     def initialize_connection_snapshot(self, snapshot, connector):
         snap = self.client.get_snap(snapshot.name)
@@ -773,6 +776,40 @@ class CommonAdapter(object):
     def terminate_connection_snapshot(self, snapshot, connector):
         snap = self.client.get_snap(snapshot.name)
         return self._terminate_connection(snap, connector)
+
+    def migrate_volume(self, volume, host):
+        """Leverage the Unity move session functionality.
+
+        This method is invoked at the source backend.
+        """
+        log_params = {
+            'name': volume.name,
+            'src_host': volume.host,
+            'dest_host': host['host']
+        }
+        LOG.info('Migrate Volume: %(name)s, host: %(src_host)s, destination: '
+                 '%(dest_host)s', log_params)
+
+        src_backend = utils.get_backend_name_from_volume(volume)
+        dest_backend = utils.get_backend_name_from_host(host)
+
+        if src_backend != dest_backend:
+            LOG.debug('Cross-backends migration not supported by Unity '
+                      'driver. Falling back to host-assisted migration.')
+            return False, None
+
+        lun_id = self.get_lun_id(volume)
+        dest_pool_name = utils.get_pool_name_from_host(host)
+        dest_pool_id = self.get_pool_id_by_name(dest_pool_name)
+
+        if self.client.migrate_lun(lun_id, dest_pool_id):
+            LOG.debug('Volume migrated successfully.')
+            model_update = {}
+            return True, model_update
+
+        LOG.debug('Volume migrated failed. Falling back to '
+                  'host-assisted migration.')
+        return False, None
 
 
 class ISCSIAdapter(CommonAdapter):

--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -153,6 +153,11 @@ class UnityClient(object):
                       lun_id)
         return lun
 
+    def migrate_lun(self, lun_id, dest_pool_id):
+        lun = self.system.get_lun(lun_id)
+        dest_pool = self.system.get_pool(dest_pool_id)
+        return lun.migrate(dest_pool)
+
     def get_pools(self):
         """Gets all storage pools on the Unity system.
 
@@ -339,6 +344,10 @@ class UnityClient(object):
                 qos_specs.get(utils.QOS_MAX_IOPS),
                 qos_specs.get(utils.QOS_MAX_BWS))
         return limit_policy
+
+    def get_pool_id_by_name(self, name):
+        pool = self.system.get_pool(name=name)
+        return pool.get_id()
 
     def get_pool_name(self, lun_name):
         lun = self.system.get_lun(name=lun_name)

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -57,6 +57,8 @@ class UnityDriver(driver.TransferVD,
     """Unity Driver.
 
     Version history:
+        00.04.16 - Support storage assisted volume migration (cherry pick from
+                   upstream pike)
         00.04.15 - Support compressed volume (cherry pick from downstream pike)
         00.04.14 - Fixes the bug which thick volume failed to create (cherry
                    pick from downstream pike)
@@ -79,7 +81,7 @@ class UnityDriver(driver.TransferVD,
         00.04.02 - Initial version
     """
 
-    VERSION = '00.04.15'
+    VERSION = '00.04.16'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"
@@ -121,6 +123,10 @@ class UnityDriver(driver.TransferVD,
     def delete_volume(self, volume):
         """Deletes a volume."""
         self.adapter.delete_volume(volume)
+
+    def migrate_volume(self, context, volume, host):
+        """Migrates a volume."""
+        return self.adapter.migrate_volume(volume, host)
 
     def create_snapshot(self, snapshot):
         """Creates a snapshot."""

--- a/cinder/volume/drivers/dell_emc/unity/utils.py
+++ b/cinder/volume/drivers/dell_emc/unity/utils.py
@@ -173,6 +173,18 @@ def get_pool_name(volume):
     return vol_utils.extract_host(volume.host, 'pool')
 
 
+def get_pool_name_from_host(host):
+    return vol_utils.extract_host(host['host'], 'pool')
+
+
+def get_backend_name_from_volume(volume):
+    return vol_utils.extract_host(volume.host, 'backend')
+
+
+def get_backend_name_from_host(host):
+    return vol_utils.extract_host(host['host'], 'backend')
+
+
 def get_extra_spec(volume, spec_key):
     spec_value = None
     type_id = volume.volume_type_id

--- a/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
@@ -15,7 +15,7 @@ Prerequisites
 +===================+=================+
 | Unity OE          | 4.1.X or newer  |
 +-------------------+-----------------+
-| storops           | 0.5.10 or newer |
+| storops           | 1.1.0 or newer  |
 +-------------------+-----------------+
 
 
@@ -248,7 +248,7 @@ following commands to create a thick volume.
 
 
 Compressed volume support
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Unity driver supports ``compressed volume`` creation, modification and
 deletion. In order to create a compressed volume, a volume type which
@@ -264,6 +264,23 @@ Then create volume and specify the new created volume type.
 .. note:: In Unity, only All-Flash pools support compressed volume, for the
           other type of pools, "'compression_support': False" will be
           returned when getting pool stats.
+
+
+Storage-assisted volume migration support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unity driver supports storage-assisted volume migration, when the user starts
+migrating with ``cinder migrate --force-host-copy False <volume_id> <host>`` or
+``cinder migrate <volume_id> <host>``, cinder will try to leverage the Unity's
+native volume migration functionality. If Unity fails to migrate the volume,
+host-assisted migration will be triggered.
+
+In the following scenarios, Unity storage-assisted volume migration will not be
+triggered. Instead, host-assisted volume migration will be triggered:
+
+- Volume is to be migrated across backends.
+- Migration of cloned volume. For example, if vol_2 was cloned from vol_1,
+  the storage-assisted volume migration of vol_2 will not be triggered.
 
 
 QoS support

--- a/releasenotes/notes/unity-storage-assisted-migration-support-145fce87f36f1ecc.yaml
+++ b/releasenotes/notes/unity-storage-assisted-migration-support-145fce87f36f1ecc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Dell EMC Unity Driver: Added storage-assisted migration support.


### PR DESCRIPTION
Adds storage-assisted migration support for Unity driver.

Change-Id: Ibaf2e6a09f93b167b6b1477d5653922d807fccce
Implements: blueprint unity-storage-assisted-volume-migration-support
(cherry picked from commit 17bef5e591ebd82ec41f1e4c34a2874db80669ec)
(cherry picked from commit 9d577fccc6b8a504de633750f30c2fba6353ce4f)