### PR TITLE
[Unity] Compressed volume support

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -79,7 +79,8 @@ class MockClient(object):
         return test_client.MockResourceList(['pool0', 'pool1'])
 
     @staticmethod
-    def create_lun(name, size, pool, description=None, io_limit_policy=None):
+    def create_lun(name, size, pool, description=None, io_limit_policy=None,
+                   is_compressed=None):
         return test_client.MockResource(_id=name, name=name)
 
     @staticmethod
@@ -395,6 +396,16 @@ class CommonAdapterTest(test.TestCase):
         expected = get_lun_pl('lun_3')
         self.assertEqual(expected, ret['provider_location'])
 
+    @patch_for_unity_adapter
+    def test_create_compressed_volume(self):
+        volume_type = MockOSResource(
+            extra_specs={'compression_support': '<is> True'})
+        volume = MockOSResource(name='lun_3', size=5, host='unity#pool1',
+                                group=None, volume_type=volume_type)
+        ret = self.adapter.create_volume(volume)
+        expected = get_lun_pl('lun_3')
+        self.assertEqual(expected, ret['provider_location'])
+
     def test_create_snapshot(self):
         volume = MockOSResource(provider_location='id^lun_43')
         snap = MockOSResource(volume=volume, name='abc-def_snap')
@@ -435,6 +446,7 @@ class CommonAdapterTest(test.TestCase):
         self.assertEqual(5, stats['reserved_percentage'])
         self.assertFalse(stats['thick_provisioning_support'])
         self.assertTrue(stats['thin_provisioning_support'])
+        self.assertTrue(stats['compression_support'])
         self.assertTrue(stats['consistent_group_snapshot_enabled'])
 
     def test_update_volume_stats(self):

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -50,6 +50,7 @@ class MockResource(object):
         self.pool_name = 'Pool0'
         self._storage_resource = None
         self.host_cache = []
+        self.is_all_flash = True
         self.description = None
         self.luns = None
         self.lun = None
@@ -116,7 +117,8 @@ class MockResource(object):
         return self.alu_hlu_map.get(lun.get_id(), None)
 
     @staticmethod
-    def create_lun(lun_name, size_gb, description=None, io_limit_policy=None):
+    def create_lun(lun_name, size_gb, description=None, io_limit_policy=None,
+                   is_compression=None):
         if lun_name == 'in_use':
             raise ex.UnityLunNameInUseError()
         ret = MockResource(lun_name, 'lun_2')

--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -57,7 +57,8 @@ class UnityClient(object):
         return self.system.serial_number
 
     def create_lun(self, name, size, pool, description=None,
-                   io_limit_policy=None, cg_name=None):
+                   io_limit_policy=None, is_compressed=None,
+                   cg_name=None):
         """Creates LUN on the Unity system.
 
         :param name: lun name
@@ -65,12 +66,14 @@ class UnityClient(object):
         :param pool: UnityPool object represent to pool to place the lun
         :param description: lun description
         :param io_limit_policy: io limit on the LUN
+        :param is_compressed: is compressed LUN enabled
         :return: UnityLun object
         """
         try:
             lun = pool.create_lun(lun_name=name, size_gb=size,
                                   description=description,
-                                  io_limit_policy=io_limit_policy)
+                                  io_limit_policy=io_limit_policy,
+                                  is_compression=is_compressed)
         except storops_ex.UnityLunNameInUseError:
             LOG.debug("LUN %s already exists. Return the existing one.",
                       name)

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -76,14 +76,17 @@ class UnityDriver(driver.ManageableVD,
         3.1.0 - Support revert to snapshot API
         4.0.0 - Support remove empty host
         4.1.0 - Support generic group and consistent group
-        4.2.0 - Fixes bug 1879705 to make sure lun could be deleted
-                even though the lun has hosts accessed.
-        4.3.0 - Support new QoS keys
+        4.2.0 - Fixes bug 1879705 to make sure lun could be deleted even
+                though the lun has hosts accessed. (cherry pick from
+                downstream train)
+        4.3.0 - Support new QoS keys (cherry pick from downstream train)
         4.4.0 - Fixes bug 1883677 to convert the value of total_bytes_sec
-                to KBPS to set correct bandwidth
+                to KBPS to set correct bandwidth (cherry pick from
+                downstream train)
+        4.5.0 - Support compressed volume (cherry pick from upstream rocky)
     """
 
-    VERSION = '04.04.00'
+    VERSION = '04.05.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
@@ -23,6 +23,7 @@ Supported operations
 ~~~~~~~~~~~~~~~~~~~~
 
 - Create, delete, attach, and detach volumes.
+- Create, delete, attach, and detach compressed volumes.
 - Create, list, and delete volume snapshots.
 - Create a volume from a snapshot.
 - Copy an image to a volume.
@@ -243,6 +244,25 @@ Thin and thick provisioning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Only thin volume provisioning is supported in Unity volume driver.
+
+
+Compressed volume support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unity driver supports ``compressed volume`` creation, modification and
+deletion. In order to create a compressed volume, a volume type which
+enables compression support needs to be created first:
+
+.. code-block:: console
+
+   $ openstack volume type create CompressedVolumeType
+   $ openstack volume type set --property provisioning:type=compressed --property compression_support='<is> True' CompressedVolumeType
+
+Then create volume and specify the new created volume type.
+
+.. note:: In Unity, only All-Flash pools support compressed volume, for the
+          other type of pools, "'compression_support': False" will be
+          returned when getting pool stats.
 
 
 QoS support

--- a/releasenotes/notes/unity-compressed-volume-support-4998dee84534a324.yaml
+++ b/releasenotes/notes/unity-compressed-volume-support-4998dee84534a324.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Dell EMC Unity driver: Add compressed volume support.


### PR DESCRIPTION
Support operations are:

Create/delete/clone/extend/attach/detach compressed volumes

Change-Id: I43d840875ebb99744d23d87482603e34551c3882
Implements: blueprint unity-compressed-volume-support
(cherry picked from commit 2da949da1f79a0121d75c50eecdd102382287bda)