### PR TITLE
[Unity] Storage-assisted migration support

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -220,6 +220,18 @@ class MockClient(object):
     def restore_snapshot(self, snap_name):
         return test_client.MockResource(name="back_snap")
 
+    def get_pool_id_by_name(self, name):
+        pools = {'PoolA': 'pool_1',
+                 'PoolB': 'pool_2',
+                 'PoolC': 'pool_3'}
+        return pools.get(name, None)
+
+    def migrate_lun(self, lun_id, dest_pool_id):
+        if dest_pool_id == 'pool_2':
+            return True
+        if dest_pool_id == 'pool_3':
+            return False
+
 
 class MockLookupService(object):
     @staticmethod
@@ -799,6 +811,38 @@ class CommonAdapterTest(test.TestCase):
         volume = MockOSResource(id='1', name='vol_1')
         snapshot = MockOSResource(id='2', name='snap_1')
         self.adapter.restore_snapshot(volume, snapshot)
+
+    def test_get_pool_id_by_name(self):
+        pool_name = 'PoolA'
+        pool_id = self.adapter.get_pool_id_by_name(pool_name)
+        self.assertEqual('pool_1', pool_id)
+
+    def test_migrate_volume(self):
+        provider_location = 'id^1|system^FNM001|type^lun|version^05.00'
+        volume = MockOSResource(id='1', name='vol_1',
+                                host='HostA@BackendB#PoolA',
+                                provider_location=provider_location)
+        host = {'host': 'HostA@BackendB#PoolB'}
+        ret = self.adapter.migrate_volume(volume, host)
+        self.assertEqual((True, {}), ret)
+
+    def test_migrate_volume_failed(self):
+        provider_location = 'id^1|system^FNM001|type^lun|version^05.00'
+        volume = MockOSResource(id='1', name='vol_1',
+                                host='HostA@BackendB#PoolA',
+                                provider_location=provider_location)
+        host = {'host': 'HostA@BackendB#PoolC'}
+        ret = self.adapter.migrate_volume(volume, host)
+        self.assertEqual((False, None), ret)
+
+    def test_migrate_volume_cross_backends(self):
+        provider_location = 'id^1|system^FNM001|type^lun|version^05.00'
+        volume = MockOSResource(id='1', name='vol_1',
+                                host='HostA@BackendA#PoolA',
+                                provider_location=provider_location)
+        host = {'host': 'HostA@BackendB#PoolB'}
+        ret = self.adapter.migrate_volume(volume, host)
+        self.assertEqual((False, None), ret)
 
     @ddt.unpack
     @ddt.data((('group-1', 'group-1_name', 'group-1_description'),

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -202,6 +202,11 @@ class MockResource(object):
     def restore(self, delete_backup):
         return MockResource(_id='snap_1', name="internal_snap")
 
+    def migrate(self, dest_pool):
+        if dest_pool.id == 'pool_2':
+            return False
+        return True
+
 
 class MockResourceList(object):
     def __init__(self, names=None, ids=None):
@@ -274,7 +279,11 @@ class MockSystem(object):
         return MockResource(name, _id)
 
     @staticmethod
-    def get_pool():
+    def get_pool(_id=None, name=None):
+        if name == 'Pool 3':
+            return MockResource(name, 'pool_3')
+        if name or _id:
+            return MockResource(name, _id)
         return MockResourceList(['Pool 1', 'Pool 2'])
 
     @staticmethod
@@ -590,6 +599,17 @@ class ClientTest(unittest.TestCase):
     def test_expand_lun_nothing_to_modify(self):
         lun = self.client.extend_lun('ev_4', 5)
         self.assertEqual(5, lun.total_size_gb)
+
+    def test_migrate_lun_success(self):
+        ret = self.client.migrate_lun('lun_0', 'pool_1')
+        self.assertTrue(ret)
+
+    def test_migrate_lun_failed(self):
+        ret = self.client.migrate_lun('lun_0', 'pool_2')
+        self.assertFalse(ret)
+
+    def test_get_pool_id_by_name(self):
+        self.assertEqual('pool_3', self.client.get_pool_id_by_name('Pool 3'))
 
     def test_get_pool_name(self):
         self.assertEqual('Pool0', self.client.get_pool_name('lun_0'))

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_driver.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_driver.py
@@ -104,6 +104,10 @@ class MockAdapter(object):
         return True
 
     @staticmethod
+    def migrate_volume(volume, host):
+        return True, {}
+
+    @staticmethod
     def create_group(group):
         return group
 
@@ -240,6 +244,13 @@ class UnityDriverTest(unittest.TestCase):
         volume = self.get_volume()
         self.driver.delete_volume(volume)
         self.assertFalse(volume.exists)
+
+    def test_migrate_volume(self):
+        volume = self.get_volume()
+        ret = self.driver.migrate_volume(self.get_context(),
+                                         volume,
+                                         'HostA@BackendB#PoolC')
+        self.assertEqual((True, {}), ret)
 
     def test_create_snapshot(self):
         snapshot = self.get_snapshot()

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_utils.py
@@ -236,6 +236,21 @@ class UnityUtilsTest(unittest.TestCase):
         volume = test_adapter.MockOSResource(host='host@backend#pool_name')
         self.assertEqual('pool_name', utils.get_pool_name(volume))
 
+    def test_get_pool_name_from_host(self):
+        host = {'host': 'host@backend#pool_name'}
+        ret = utils.get_pool_name_from_host(host)
+        self.assertEqual('pool_name', ret)
+
+    def get_backend_name_from_volume(self):
+        volume = test_adapter.MockOSResource(host='host@backend#pool_name')
+        ret = utils.get_backend_name_from_volume(volume)
+        self.assertEqual('host@backend', ret)
+
+    def get_backend_name_from_host(self):
+        host = {'host': 'host@backend#pool_name'}
+        ret = utils.get_backend_name_from_volume(host)
+        self.assertEqual('host@backend', ret)
+
     def test_ignore_exception(self):
         class IgnoredException(Exception):
             pass

--- a/cinder/volume/drivers/dell_emc/unity/adapter.py
+++ b/cinder/volume/drivers/dell_emc/unity/adapter.py
@@ -773,6 +773,9 @@ class CommonAdapter(object):
     def get_pool_name(self, volume):
         return self.client.get_pool_name(volume.name)
 
+    def get_pool_id_by_name(self, name):
+        return self.client.get_pool_id_by_name(name=name)
+
     @cinder_utils.trace
     def initialize_connection_snapshot(self, snapshot, connector):
         snap = self.client.get_snap(snapshot.name)
@@ -786,6 +789,40 @@ class CommonAdapter(object):
     @cinder_utils.trace
     def restore_snapshot(self, volume, snapshot):
         return self.client.restore_snapshot(snapshot.name)
+
+    def migrate_volume(self, volume, host):
+        """Leverage the Unity move session functionality.
+
+        This method is invoked at the source backend.
+        """
+        log_params = {
+            'name': volume.name,
+            'src_host': volume.host,
+            'dest_host': host['host']
+        }
+        LOG.info('Migrate Volume: %(name)s, host: %(src_host)s, destination: '
+                 '%(dest_host)s', log_params)
+
+        src_backend = utils.get_backend_name_from_volume(volume)
+        dest_backend = utils.get_backend_name_from_host(host)
+
+        if src_backend != dest_backend:
+            LOG.debug('Cross-backends migration not supported by Unity '
+                      'driver. Falling back to host-assisted migration.')
+            return False, None
+
+        lun_id = self.get_lun_id(volume)
+        dest_pool_name = utils.get_pool_name_from_host(host)
+        dest_pool_id = self.get_pool_id_by_name(dest_pool_name)
+
+        if self.client.migrate_lun(lun_id, dest_pool_id):
+            LOG.debug('Volume migrated successfully.')
+            model_update = {}
+            return True, model_update
+
+        LOG.debug('Volume migrated failed. Falling back to '
+                  'host-assisted migration.')
+        return False, None
 
     def create_group(self, group):
         """Creates a generic group.

--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -144,6 +144,11 @@ class UnityClient(object):
                       lun_id)
         return lun
 
+    def migrate_lun(self, lun_id, dest_pool_id):
+        lun = self.system.get_lun(lun_id)
+        dest_pool = self.system.get_pool(dest_pool_id)
+        return lun.migrate(dest_pool)
+
     def get_pools(self):
         """Gets all storage pools on the Unity system.
 
@@ -339,6 +344,10 @@ class UnityClient(object):
                 qos_specs.get(utils.QOS_MAX_IOPS),
                 qos_specs.get(utils.QOS_MAX_BWS))
         return limit_policy
+
+    def get_pool_id_by_name(self, name):
+        pool = self.system.get_pool(name=name)
+        return pool.get_id()
 
     def get_pool_name(self, lun_name):
         lun = self.system.get_lun(name=lun_name)

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -85,9 +85,11 @@ class UnityDriver(driver.ManageableVD,
                 downstream train)
         4.5.0 - Support compressed volume (cherry pick from upstream rocky)
         4.6.0 - Support thick volume (cherry pick from upstream rocky)
+        4.7.0 - Support storage assisted volume migration (cherry pick from
+                upstream stein)
     """
 
-    VERSION = '04.06.00'
+    VERSION = '04.07.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"
@@ -129,6 +131,10 @@ class UnityDriver(driver.ManageableVD,
     def delete_volume(self, volume):
         """Deletes a volume."""
         self.adapter.delete_volume(volume)
+
+    def migrate_volume(self, context, volume, host):
+        """Migrates a volume."""
+        return self.adapter.migrate_volume(volume, host)
 
     def create_snapshot(self, snapshot):
         """Creates a snapshot."""

--- a/cinder/volume/drivers/dell_emc/unity/utils.py
+++ b/cinder/volume/drivers/dell_emc/unity/utils.py
@@ -179,6 +179,18 @@ def get_pool_name(volume):
     return vol_utils.extract_host(volume.host, 'pool')
 
 
+def get_pool_name_from_host(host):
+    return vol_utils.extract_host(host['host'], 'pool')
+
+
+def get_backend_name_from_volume(volume):
+    return vol_utils.extract_host(volume.host, 'backend')
+
+
+def get_backend_name_from_host(host):
+    return vol_utils.extract_host(host['host'], 'backend')
+
+
 def get_extra_spec(volume, spec_key):
     spec_value = None
     type_id = volume.volume_type_id

--- a/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
+++ b/doc/source/configuration/block-storage/drivers/dell-emc-unity-driver.rst
@@ -255,7 +255,7 @@ following commands to create a thick volume.
 
 
 Compressed volume support
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Unity driver supports ``compressed volume`` creation, modification and
 deletion. In order to create a compressed volume, a volume type which
@@ -271,6 +271,23 @@ Then create volume and specify the new created volume type.
 .. note:: In Unity, only All-Flash pools support compressed volume, for the
           other type of pools, "'compression_support': False" will be
           returned when getting pool stats.
+
+
+Storage-assisted volume migration support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unity driver supports storage-assisted volume migration, when the user starts
+migrating with ``cinder migrate --force-host-copy False <volume_id> <host>`` or
+``cinder migrate <volume_id> <host>``, cinder will try to leverage the Unity's
+native volume migration functionality. If Unity fails to migrate the volume,
+host-assisted migration will be triggered.
+
+In the following scenarios, Unity storage-assisted volume migration will not be
+triggered. Instead, host-assisted volume migration will be triggered:
+
+- Volume is to be migrated across backends.
+- Migration of cloned volume. For example, if vol_2 was cloned from vol_1,
+  the storage-assisted volume migration of vol_2 will not be triggered.
 
 
 QoS support

--- a/doc/source/reference/support-matrix.ini
+++ b/doc/source/reference/support-matrix.ini
@@ -1,0 +1,797 @@
+# Copyright (C) 2018 Lenovo, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+#####################################################################
+# Drivers:
+
+[driver.datacore]
+title=DataCore Storage Driver (FC, iSCSI)
+
+[driver.datera]
+title=Datera Storage Driver (iSCSI)
+
+[driver.dell_emc_xtremio]
+title=Dell EMC XtremeIO Storage Driver (FC, iSCSI)
+
+[driver.dell_emc_powermax]
+title=Dell EMC PowerMax (2000, 8000) Storage Driver (iSCSI, FC)
+
+[driver.dell_emc_ps]
+title=Dell EMC PS Series Storage Driver (iSCSI)
+
+[driver.dell_emc_sc]
+title=Dell EMC SC Series Storage Driver (iSCSI, FC)
+
+[driver.dell_emc_vxflexos]
+title=Dell EMC VxFlex OS (ScaleIO) Storage Driver (ScaleIO)
+
+[driver.dell_emc_unity]
+title=Dell EMC Unity Storage Driver (FC, iSCSI)
+
+[driver.dell_emc_vmax_af]
+title=Dell EMC VMAX Af (250F, 450F, 850F, 950F) Storage Driver (FC, iSCSI)
+
+[driver.dell_emc_vmax_3]
+title=Dell EMC VMAX3 (100K, 200K, 400K) Storage Driver (iSCSI, FC)
+
+[driver.dell_emc_vmax_v2]
+title=Dell EMC VMAX V2 (10K, 20K, 40K) Storage Driver (iSCSI, FC)
+
+[driver.dell_emc_vnx]
+title=Dell EMC VNX Storage Driver (FC, iSCSI)
+
+[driver.fujitsu_eternus]
+title=Fujitsu ETERNUS Driver (FC, iSCSI)
+
+[driver.hpe_3par]
+title=HPE 3PAR Storage Driver (FC, iSCSI)
+
+[driver.hpe_lefthand]
+title=HPE Lefthand Driver (iSCSI)
+
+[driver.hpe_mmsa]
+title=HPE MMSA Driver (iSCSI, FC)
+
+[driver.huawei_t_v1]
+title=Huawei T Series V1 Driver (iSCSI, FC)
+
+[driver.huawei_t_v2]
+title=Huawei T Series V2 Driver (iSCSI, FC)
+
+[driver.huawei_v3]
+title=Huawei V3 Series Driver (iSCSI, FC)
+
+[driver.huawei_v5]
+title=Huawei V5 Series Driver (iSCSI, FC)
+
+[driver.huawei_18000]
+title=Huawei 18000 Series Driver (iSCSI, FC)
+
+[driver.huawei_dorado]
+title=Huawei Dorado V3 Series Driver (iSCSI, FC)
+
+[driver.huawei_fusionstorage]
+title=Huawei FusionStorage Driver (dsware)
+
+[driver.ibm_ds8k]
+title=IBM DS8k Storage Driver (FC)
+
+[driver.ibm_flashsystem]
+title=IBM Flashsystem Driver (iSCSI)
+
+[driver.ibm_gpfs]
+title=IBM GPFS Storage Driver (gpfs)
+
+[driver.ibm_storwize]
+title=IBM Storwize SVC Storage Driver (iSCSI, FC)
+
+[driver.ibm_xiv]
+title=IBM XIV Storage Driver (iSCSI, FC)
+
+[driver.infinidat]
+title=Infinidat Storage Driver (iSCSI, FC)
+
+[driver.inspur]
+title=Inspur G2 Storage Driver (iSCSI, FC)
+
+[driver.kaminario]
+title=Kaminario Storage Driver (iSCSI, FC)
+
+[driver.lenovo]
+title=Lenovo Storage Driver (FC, iSCSI)
+
+[driver.linbit_drbd]
+title=LinBit DRDB Driver (DRBD)
+
+[driver.lvm]
+title=Logical Volume Manager (LVM) Reference Driver (iSCSI)
+
+[driver.nec]
+title=NEC Storage M Series Driver (iSCSI, FC)
+
+[driver.netapp_ontap]
+title=NetApp Data ONTAP Driver (iSCSI, NFS, FC)
+
+[driver.netapp_e_ef]
+title=NetApp E/EF Series Driver (iSCSI, FC)
+
+[driver.netapp_solidfire]
+title=NetApp Solidfire Driver (iSCSI)
+
+[driver.nexenta]
+title=Nexenta Driver (iSCSI, NFS)
+
+[driver.nfs]
+title=Generic NFS Reference Driver (NFS)
+
+[driver.nimble]
+title=Nimble Storage Driver (iSCSI)
+
+[driver.prophetstor]
+title=ProphetStor Flexvisor Driver (iSCSI, NFS)
+
+[driver.oracle_zfssa]
+title=Oracle ZFSSA Driver (iSCSI, NFS)
+
+[driver.pure]
+title=Pure Storage Driver (iSCSI, FC)
+
+[driver.qnap]
+title=QNAP Storage Driver (iSCSI)
+
+[driver.quobyte]
+title=Quobyte Storage Driver (quobyte)
+
+[driver.rbd]
+title=RBD (Ceph) Storage Driver (RBD)
+
+[driver.sheepdog]
+title=Sheepdog Storage Driver (sheepdog)
+
+[driver.storpool]
+title=StorPool Storage Driver (storpool)
+
+[driver.synology]
+title=Synology Storage Driver (iSCSI)
+
+[driver.tintri]
+title=Tintri Storage Driver (NFS)
+
+[driver.vrtshyperscale]
+title=Veritas HyperScale Driver (veritas)
+
+[driver.vrtsaccess]
+title=Veritas Access iSCSI Driver (iSCSI)
+
+[driver.vrtscnfs]
+title=Veritas Cluster NFS Driver (NFS)
+
+[driver.vzstorage]
+title=Virtuozzo Storage Driver (remotefs)
+
+[driver.vmware]
+title=VMWare Storage Driver (vmdk)
+
+[driver.win_iscsi]
+title=Windows iSCSI Driver
+
+[driver.win_smb]
+title=Windows SMB Driver
+
+[driver.zadara]
+title=Zadara Storage Driver (iSCSI, NFS)
+
+#####################################################################
+# Functions:
+[operation.supported]
+title=Supported Vendor Driver
+status=optional
+notes=A vendor driver is considered supported if the vendor is
+  running a third party CI that regularly runs and reports
+  accurate results. If a vendor doesn't meet this requirement
+  the driver is marked unsupported and is removed if the problem
+  isn't resolved before the end of the subsequent release.
+driver.datacore=missing
+driver.datera=complete
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=complete
+driver.dell_emc_sc=complete
+driver.dell_emc_unity=complete
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=complete
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=complete
+driver.dell_emc_xtremio=complete
+driver.fujitsu_eternus=complete
+driver.hpe_3par=complete
+driver.hpe_lefthand=complete
+driver.hpe_mmsa=complete
+driver.huawei_t_v1=complete
+driver.huawei_t_v2=complete
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=complete
+driver.infinidat=complete
+driver.ibm_ds8k=complete
+driver.ibm_flashsystem=complete
+driver.ibm_gpfs=complete
+driver.ibm_storwize=complete
+driver.ibm_xiv=complete
+driver.inspur=complete
+driver.kaminario=complete
+driver.lenovo=complete
+driver.linbit_drbd=complete
+driver.lvm=complete
+driver.nec=complete
+driver.netapp_ontap=complete
+driver.netapp_e_ef=complete
+driver.netapp_solidfire=complete
+driver.nexenta=complete
+driver.nfs=complete
+driver.nimble=complete
+driver.oracle_zfssa=complete
+driver.prophetstor=complete
+driver.pure=complete
+driver.qnap=complete
+driver.quobyte=complete
+driver.rbd=complete
+driver.sheepdog=complete
+driver.storpool=complete
+driver.synology=complete
+driver.tintri=missing
+driver.vrtshyperscale=complete
+driver.vrtsaccess=complete
+driver.vrtscnfs=complete
+driver.vzstorage=complete
+driver.vmware=complete
+driver.win_iscsi=complete
+driver.win_smb=complete
+driver.zadara=complete
+
+[operation.online_extend_support]
+title=Extend an Attached Volume
+status=optional
+notes=Cinder supports the ability to extend a volume that is attached to
+  an instance, but not all drivers are able to do this.
+driver.datacore=complete
+driver.datera=complete
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=complete
+driver.dell_emc_sc=complete
+driver.dell_emc_unity=complete
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=complete
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=complete
+driver.dell_emc_xtremio=complete
+driver.fujitsu_eternus=complete
+driver.hpe_3par=complete
+driver.hpe_lefthand=complete
+driver.hpe_mmsa=complete
+driver.huawei_t_v1=complete
+driver.huawei_t_v2=complete
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=complete
+driver.infinidat=complete
+driver.ibm_ds8k=complete
+driver.ibm_flashsystem=complete
+driver.ibm_gpfs=complete
+driver.ibm_storwize=complete
+driver.ibm_xiv=complete
+driver.inspur=complete
+driver.kaminario=complete
+driver.lenovo=complete
+driver.linbit_drbd=complete
+driver.lvm=complete
+driver.nec=complete
+driver.netapp_ontap=missing
+driver.netapp_e_ef=complete
+driver.netapp_solidfire=complete
+driver.nexenta=complete
+driver.nfs=complete
+driver.nimble=complete
+driver.oracle_zfssa=complete
+driver.prophetstor=complete
+driver.pure=complete
+driver.qnap=complete
+driver.quobyte=complete
+driver.rbd=missing
+driver.sheepdog=complete
+driver.storpool=complete
+driver.synology=complete
+driver.tintri=complete
+driver.vrtsaccess=complete
+driver.vrtscnfs=complete
+driver.vrtshyperscale=missing
+driver.vzstorage=complete
+driver.vmware=complete
+driver.win_iscsi=complete
+driver.win_smb=complete
+driver.zadara=complete
+
+[operation.attach_snapshot]
+title=Snapshot Attachment
+status=optional
+notes=This is the ability to directly attach a snapshot to an
+  instance like a volume.
+driver.datacore=missing
+driver.datera=missing
+driver.dell_emc_powermax=missing
+driver.dell_emc_ps=missing
+driver.dell_emc_sc=missing
+driver.dell_emc_unity=complete
+driver.dell_emc_vmax_af=missing
+driver.dell_emc_vmax_3=missing
+driver.dell_emc_vmax_v2=missing
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=complete
+driver.dell_emc_xtremio=missing
+driver.fujitsu_eternus=missing
+driver.hpe_3par=missing
+driver.hpe_lefthand=missing
+driver.hpe_mmsa=missing
+driver.huawei_t_v1=complete
+driver.huawei_t_v2=complete
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=complete
+driver.infinidat=missing
+driver.ibm_ds8k=missing
+driver.ibm_flashsystem=missing
+driver.ibm_gpfs=missing
+driver.ibm_storwize=complete
+driver.ibm_xiv=missing
+driver.inspur=complete
+driver.kaminario=missing
+driver.lenovo=missing
+driver.linbit_drbd=missing
+driver.lvm=missing
+driver.nec=complete
+driver.netapp_ontap=missing
+driver.netapp_e_ef=missing
+driver.netapp_solidfire=missing
+driver.nexenta=missing
+driver.nfs=missing
+driver.nimble=missing
+driver.oracle_zfssa=missing
+driver.prophetstor=missing
+driver.pure=missing
+driver.qnap=missing
+driver.quobyte=missing
+driver.rbd=missing
+driver.sheepdog=missing
+driver.storpool=missing
+driver.synology=missing
+driver.tintri=missing
+driver.vrtshyperscale=missing
+driver.vrtsaccess=missing
+driver.vrtscnfs=missing
+driver.vzstorage=missing
+driver.vmware=missing
+driver.win_iscsi=missing
+driver.win_smb=complete
+driver.zadara=missing
+
+[operation.qos]
+title=QoS
+status=optional
+notes=Vendor drivers that support Quality of Service (QoS) are able
+  to utilize QoS Specs associated with volume extra specs to control
+  QoS settings on a per volume basis.
+driver.datacore=missing
+driver.datera=complete
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=missing
+driver.dell_emc_sc=complete
+driver.dell_emc_unity=complete
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=missing
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=complete
+driver.dell_emc_xtremio=missing
+driver.fujitsu_eternus=missing
+driver.hpe_3par=complete
+driver.hpe_lefthand=missing
+driver.hpe_mmsa=missing
+driver.huawei_t_v1=missing
+driver.huawei_t_v2=complete
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=missing
+driver.infinidat=complete
+driver.ibm_ds8k=missing
+driver.ibm_flashsystem=missing
+driver.ibm_gpfs=missing
+driver.ibm_storwize=complete
+driver.ibm_xiv=missing
+driver.inspur=complete
+driver.kaminario=missing
+driver.lenovo=missing
+driver.linbit_drbd=missing
+driver.lvm=missing
+driver.nec=complete
+driver.netapp_ontap=complete
+driver.netapp_e_ef=missing
+driver.netapp_solidfire=complete
+driver.nexenta=missing
+driver.nfs=missing
+driver.nimble=missing
+driver.oracle_zfssa=missing
+driver.prophetstor=missing
+driver.pure=missing
+driver.qnap=missing
+driver.quobyte=missing
+driver.rbd=missing
+driver.sheepdog=missing
+driver.storpool=missing
+driver.synology=missing
+driver.tintri=missing
+driver.vrtshyperscale=missing
+driver.vrtsaccess=missing
+driver.vrtscnfs=missing
+driver.vzstorage=missing
+driver.vmware=missing
+driver.win_iscsi=missing
+driver.win_smb=missing
+driver.zadara=missing
+
+[operation.volume_replication]
+title=Volume Replication
+status=optional
+notes=Vendor drivers that support volume replication can report this
+  capability to be utilized by the scheduler allowing users to request
+  replicated volumes via extra specs.  Such drivers are also then able
+  to take advantage of Cinder's failover and failback commands.
+driver.datacore=missing
+driver.datera=missing
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=missing
+driver.dell_emc_sc=complete
+driver.dell_emc_unity=missing
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=missing
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=missing
+driver.dell_emc_xtremio=missing
+driver.fujitsu_eternus=missing
+driver.hpe_3par=complete
+driver.hpe_lefthand=complete
+driver.hpe_mmsa=missing
+driver.huawei_t_v1=missing
+driver.huawei_t_v2=missing
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=missing
+driver.infinidat=missing
+driver.ibm_ds8k=complete
+driver.ibm_flashsystem=missing
+driver.ibm_gpfs=missing
+driver.ibm_storwize=complete
+driver.ibm_xiv=complete
+driver.inspur=complete
+driver.kaminario=complete
+driver.lenovo=missing
+driver.linbit_drbd=missing
+driver.lvm=missing
+driver.nec=missing
+driver.netapp_ontap=complete
+driver.netapp_e_ef=missing
+driver.netapp_solidfire=complete
+driver.nexenta=missing
+driver.nfs=missing
+driver.nimble=missing
+driver.oracle_zfssa=missing
+driver.prophetstor=missing
+driver.pure=complete
+driver.qnap=missing
+driver.quobyte=missing
+driver.rbd=missing
+driver.sheepdog=missing
+driver.storpool=complete
+driver.synology=missing
+driver.tintri=missing
+driver.vrtshyperscale=missing
+driver.vrtsaccess=missing
+driver.vrtscnfs=missing
+driver.vzstorage=missing
+driver.vmware=missing
+driver.win_iscsi=missing
+driver.win_smb=missing
+driver.zadara=missing
+
+[operation.consistency_groups]
+title=Consistency Groups
+status=optional
+notes=Vendor drivers that support consistency groups are able to
+  logically group volumes together for things like snapshotting and
+  deletion.  Grouping the volumes ensures that operations are only
+  completed on the group of volumes, not individually, enabling the
+  creation of consistent snapshots across a group.
+driver.datacore=missing
+driver.datera=missing
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=missing
+driver.dell_emc_sc=complete
+driver.dell_emc_unity=missing
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=complete
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=complete
+driver.dell_emc_xtremio=complete
+driver.fujitsu_eternus=missing
+driver.hpe_3par=complete
+driver.hpe_lefthand=complete
+driver.hpe_mmsa=missing
+driver.huawei_t_v1=missing
+driver.huawei_t_v2=missing
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=missing
+driver.infinidat=missing
+driver.ibm_ds8k=complete
+driver.ibm_flashsystem=missing
+driver.ibm_gpfs=missing
+driver.ibm_storwize=complete
+driver.ibm_xiv=complete
+driver.inspur=complete
+driver.kaminario=missing
+driver.lenovo=missing
+driver.linbit_drbd=missing
+driver.lvm=missing
+driver.nec=missing
+driver.netapp_ontap=complete
+driver.netapp_e_ef=complete
+driver.netapp_solidfire=complete
+driver.nexenta=missing
+driver.nfs=missing
+driver.nimble=missing
+driver.oracle_zfssa=missing
+driver.prophetstor=complete
+driver.pure=complete
+driver.qnap=missing
+driver.quobyte=missing
+driver.rbd=missing
+driver.sheepdog=missing
+driver.storpool=missing
+driver.synology=missing
+driver.tintri=missing
+driver.vrtshyperscale=missing
+driver.vrtsaccess=missing
+driver.vrtscnfs=missing
+driver.vzstorage=missing
+driver.vmware=missing
+driver.win_iscsi=missing
+driver.win_smb=missing
+driver.zadara=missing
+
+[operation.thin_provisioning]
+title=Thin Provisioning
+status=optional
+notes=If a volume driver supports thin provisioning it means that it
+  will allow the scheduler to provision more storage space
+  than physically exists on the backend. This may also be called
+  'oversubscription'.
+driver.datacore=missing
+driver.datera=missing
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=complete
+driver.dell_emc_sc=complete
+driver.dell_emc_unity=complete
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=complete
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=complete
+driver.dell_emc_xtremio=complete
+driver.fujitsu_eternus=missing
+driver.hpe_3par=complete
+driver.hpe_lefthand=complete
+driver.hpe_mmsa=missing
+driver.huawei_t_v1=missing
+driver.huawei_t_v2=missing
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=missing
+driver.infinidat=complete
+driver.ibm_ds8k=missing
+driver.ibm_flashsystem=missing
+driver.ibm_gpfs=missing
+driver.ibm_storwize=missing
+driver.ibm_xiv=missing
+driver.inspur=missing
+driver.kaminario=complete
+driver.lenovo=missing
+driver.linbit_drbd=missing
+driver.lvm=complete
+driver.nec=missing
+driver.netapp_ontap=complete
+driver.netapp_e_ef=complete
+driver.netapp_solidfire=complete
+driver.nexenta=missing
+driver.nfs=complete
+driver.nimble=missing
+driver.oracle_zfssa=complete
+driver.prophetstor=missing
+driver.pure=complete
+driver.qnap=missing
+driver.quobyte=missing
+driver.rbd=missing
+driver.sheepdog=missing
+driver.storpool=missing
+driver.synology=missing
+driver.tintri=missing
+driver.vrtshyperscale=missing
+driver.vrtsaccess=missing
+driver.vrtscnfs=missing
+driver.vzstorage=missing
+driver.vmware=missing
+driver.win_iscsi=missing
+driver.win_smb=complete
+driver.zadara=missing
+
+[operation.volume_migration_storage_assisted]
+title=Volume Migration (Storage Assisted)
+status=optional
+notes=Storage assisted volume migration is like host assisted volume
+  migration except that it the a volume can be migrated without the
+  assistance of the Cinder host.  Vendor drivers that implement this
+  can migrate volumes completely through the storage backend's
+  functionality.
+driver.datacore=missing
+driver.datera=missing
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=missing
+driver.dell_emc_sc=missing
+driver.dell_emc_unity=complete
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=missing
+driver.dell_emc_vnx=complete
+driver.dell_emc_vxflexos=missing
+driver.dell_emc_xtremio=missing
+driver.fujitsu_eternus=missing
+driver.hpe_3par=missing
+driver.hpe_lefthand=missing
+driver.hpe_mmsa=missing
+driver.huawei_t_v1=missing
+driver.huawei_t_v2=missing
+driver.huawei_v3=complete
+driver.huawei_v5=complete
+driver.huawei_18000=complete
+driver.huawei_dorado=complete
+driver.huawei_fusionstorage=missing
+driver.infinidat=missing
+driver.ibm_ds8k=missing
+driver.ibm_flashsystem=missing
+driver.ibm_gpfs=missing
+driver.ibm_storwize=missing
+driver.ibm_xiv=missing
+driver.inspur=missing
+driver.kaminario=missing
+driver.lenovo=missing
+driver.linbit_drbd=missing
+driver.lvm=missing
+driver.nec=missing
+driver.netapp_ontap=missing
+driver.netapp_e_ef=missing
+driver.netapp_solidfire=missing
+driver.nexenta=missing
+driver.nfs=missing
+driver.nimble=missing
+driver.oracle_zfssa=complete
+driver.prophetstor=missing
+driver.pure=missing
+driver.qnap=missing
+driver.quobyte=missing
+driver.rbd=missing
+driver.sheepdog=missing
+driver.storpool=complete
+driver.synology=missing
+driver.tintri=missing
+driver.vrtshyperscale=missing
+driver.vrtsaccess=missing
+driver.vrtscnfs=missing
+driver.vzstorage=missing
+driver.vmware=missing
+driver.win_iscsi=missing
+driver.win_smb=missing
+driver.zadara=missing
+
+[operation.multi-attach]
+title=Multi-Attach Support
+status=optional
+notes=Vendor drivers that report multi-attach support are able
+  to make one volume available to multiple instances as once.
+  It is important to note that a clustered file system that
+  supports multi-attach functionality is required to use multi-
+  attach functionality otherwise data corruption may occur.
+driver.datacore=missing
+driver.datera=missing
+driver.dell_emc_powermax=complete
+driver.dell_emc_ps=missing
+driver.dell_emc_sc=complete
+driver.dell_emc_unity=complete
+driver.dell_emc_vmax_af=complete
+driver.dell_emc_vmax_3=complete
+driver.dell_emc_vmax_v2=missing
+driver.dell_emc_vnx=missing
+driver.dell_emc_vxflexos=complete
+driver.dell_emc_xtremio=complete
+driver.fujitsu_eternus=missing
+driver.hpe_3par=missing
+driver.hpe_lefthand=complete
+driver.hpe_mmsa=missing
+driver.huawei_t_v1=missing
+driver.huawei_t_v2=missing
+driver.huawei_v3=missing
+driver.huawei_v5=missing
+driver.huawei_18000=missing
+driver.huawei_dorado=missing
+driver.huawei_fusionstorage=missing
+driver.infinidat=complete
+driver.ibm_ds8k=complete
+driver.ibm_flashsystem=missing
+driver.ibm_gpfs=missing
+driver.ibm_storwize=complete
+driver.ibm_xiv=complete
+driver.inspur=missing
+driver.kaminario=missing
+driver.lenovo=missing
+driver.linbit_drbd=missing
+driver.lvm=complete
+driver.nec=missing
+driver.netapp_ontap=complete
+driver.netapp_e_ef=missing
+driver.netapp_solidfire=complete
+driver.nexenta=missing
+driver.nfs=missing
+driver.nimble=missing
+driver.oracle_zfssa=complete
+driver.prophetstor=missing
+driver.pure=missing
+driver.qnap=missing
+driver.quobyte=missing
+driver.rbd=missing
+driver.sheepdog=missing
+driver.storpool=missing
+driver.synology=missing
+driver.tintri=missing
+driver.vrtshyperscale=missing
+driver.vrtsaccess=missing
+driver.vrtscnfs=missing
+driver.vzstorage=missing
+driver.vmware=missing
+driver.win_iscsi=missing
+driver.win_smb=missing
+driver.zadara=missing

--- a/releasenotes/notes/unity-storage-assisted-migration-support-145fce87f36f1ecc.yaml
+++ b/releasenotes/notes/unity-storage-assisted-migration-support-145fce87f36f1ecc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Dell EMC Unity Driver: Added storage-assisted migration support.


### PR DESCRIPTION
Adds storage-assisted migration support for Unity driver.

Change-Id: Ibaf2e6a09f93b167b6b1477d5653922d807fccce
Implements: blueprint unity-storage-assisted-volume-migration-support
(cherry picked from commit 17bef5e591ebd82ec41f1e4c34a2874db80669ec)