### PR TITLE
Unity: force delete attached snapshots

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -134,7 +134,7 @@ class MockClient(object):
         return ret
 
     @staticmethod
-    def delete_snap(snap):
+    def delete_snap(snap, even_attached=False):
         if snap.name in ('abc-def_snap',):
             raise ex.SnapDeleteIsCalled()
 

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -64,14 +64,14 @@ class MockResource(object):
     def get_id(self):
         return self._id
 
-    def delete(self):
+    def delete(self, even_attached=False):
         if self.get_id() in ['snap_2']:
             raise ex.SnapDeleteIsCalled()
         elif self.get_id() == 'not_found':
             raise ex.UnityResourceNotFoundError()
         elif self.get_id() == 'snap_in_use':
             raise ex.UnityDeleteAttachedSnapError()
-        elif self.name == 'empty_host':
+        elif self.name == 'empty-host':
             raise ex.HostDeleteIsCalled()
 
     @property
@@ -634,7 +634,8 @@ class ClientTest(unittest.TestCase):
         host = MockResource(name='empty-host')
         self.client.host_cache['empty-host'] = host
         self.assertRaises(ex.HostDeleteIsCalled,
-                          self.client.delete_host_wo_lock(host))
+                          self.client.delete_host_wo_lock,
+                          host)
 
     def test_delete_host_wo_lock_remove_from_cache(self):
         host = MockResource(name='empty-host-in-cache')

--- a/cinder/volume/drivers/dell_emc/unity/adapter.py
+++ b/cinder/volume/drivers/dell_emc/unity/adapter.py
@@ -591,7 +591,7 @@ class CommonAdapter(object):
         :param snapshot: the snapshot to delete.
         """
         snap = self.client.get_snap(name=snapshot.name)
-        self.client.delete_snap(snap)
+        self.client.delete_snap(snap, even_attached=True)
 
     def _get_referenced_lun(self, existing_ref):
         if 'source-id' in existing_ref:

--- a/cinder/volume/drivers/dell_emc/unity/client.py
+++ b/cinder/volume/drivers/dell_emc/unity/client.py
@@ -190,13 +190,13 @@ class UnityClient(object):
         return snap
 
     @staticmethod
-    def delete_snap(snap):
+    def delete_snap(snap, even_attached=False):
         if snap is None:
             LOG.debug("Snap to delete is None, skipping deletion.")
             return
 
         try:
-            snap.delete()
+            snap.delete(even_attached=even_attached)
         except storops_ex.UnityResourceNotFoundError as err:
             LOG.debug("Snap %(snap_name)s may be deleted already. "
                       "Message: %(err)s",

--- a/cinder/volume/drivers/dell_emc/unity/driver.py
+++ b/cinder/volume/drivers/dell_emc/unity/driver.py
@@ -88,9 +88,10 @@ class UnityDriver(driver.ManageableVD,
         4.7.0 - Support storage assisted volume migration (cherry pick from
                 upstream stein)
         4.8.0 - Support retype volume (cherry pick from downstream train)
+        4.9.0 - Support force delete attached snapshots
     """
 
-    VERSION = '04.08.00'
+    VERSION = '04.09.00'
     VENDOR = 'Dell EMC'
     # ThirdPartySystems wiki page
     CI_WIKI_NAME = "EMC_UNITY_CI"

--- a/releasenotes/notes/unity-delete-attached-snapshots-3b5f7fed9995d09a.yaml
+++ b/releasenotes/notes/unity-delete-attached-snapshots-3b5f7fed9995d09a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Dell EMC Unity Driver: Fixes `bug 1798529
+    <https://bugs.launchpad.net/cinder/+bug/1798529>`__ to force delete the
+    snapshot even if it is attached to hosts.


### PR DESCRIPTION
Force delete the snapshot even if it is attached to hosts.

Closes-bug: #1798529
Change-Id: I53b7efc093f7fc5823e0543aca4ce57720b88f5b