### PR TITLE
[Unity]: Return existing hlu for multiattach

### DIFF
--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_adapter.py
@@ -395,6 +395,8 @@ def get_connector_uids(adapter, connector):
 
 
 def get_connection_info(adapter, hlu, host, connector):
+    if hlu == 100:
+        return {'target_luns': [100, 100], 'target_lun': 100}
     return {}
 
 
@@ -1826,6 +1828,20 @@ class ISCSIAdapterTest(test.TestCase):
         self.assertEqual('iscsi', conn_info['driver_volume_type'])
         self.assertTrue(conn_info['data']['target_discovered'])
         self.assertEqual('id_43', conn_info['data']['volume_id'])
+
+    @patch_for_iscsi_adapter
+    def test_initialize_connection_multiattached_volume(self):
+        volume = MockOSResource(provider_location='id^lun_multiattached',
+                                id='lun_multiattached',
+                                name='lun_multiattached',
+                                multiattach=True)
+        connector = {'host': 'host1'}
+        conn_info = self.adapter.initialize_connection(volume, connector)
+        self.assertEqual('iscsi', conn_info['driver_volume_type'])
+        self.assertTrue(conn_info['data']['target_discovered'])
+        self.assertEqual('lun_multiattached', conn_info['data']['volume_id'])
+        self.assertEqual([100, 100], conn_info['data']['target_luns'])
+        self.assertEqual(100, conn_info['data']['target_lun'])
 
     @patch_for_iscsi_adapter
     def test_initialize_connection_snapshot(self):

--- a/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
+++ b/cinder/tests/unit/volume/drivers/dell_emc/unity/test_client.py
@@ -121,6 +121,8 @@ class MockResource(object):
             raise ex.DetachFromIsCalled()
 
     def get_hlu(self, lun):
+        if lun.name == 'lun_multiattached':
+            return 100
         return self.alu_hlu_map.get(lun.get_id(), None)
 
     @staticmethod
@@ -300,6 +302,8 @@ class MockSystem(object):
             host_access_2.host = MockResource(name='host_2', _id='host_2')
             lun.host_access = [host_access_1, host_access_2]
             return lun
+        if _id == 'lun_multiattached':
+            return MockResource(name=_id, _id=_id)
         return MockResource(name, _id)
 
     @staticmethod


### PR DESCRIPTION
Return existing hlu for multi-attached volume, to fix the faulty
device issue.

Change-Id: Ic27d2c2b0f4de102662bd49a7b8e70649b7889a9